### PR TITLE
fix issue where trailing slash is removed for star segments

### DIFF
--- a/dist/route-recognizer.amd.js
+++ b/dist/route-recognizer.amd.js
@@ -432,7 +432,8 @@ define("route-recognizer",
 
       recognize: function(path) {
         var states = [ this.rootState ],
-            pathLen, i, l, queryStart, queryParams = {};
+            pathLen, i, l, queryStart, queryParams = {}, 
+            isSlashDropped = false;
 
         queryStart = path.indexOf('?');
         if (queryStart !== -1) {
@@ -448,6 +449,7 @@ define("route-recognizer",
         pathLen = path.length;
         if (pathLen > 1 && path.charAt(pathLen - 1) === "/") {
           path = path.substr(0, pathLen - 1);
+          isSlashDropped = true;
         }
 
         for (i=0, l=path.length; i<l; i++) {
@@ -467,12 +469,17 @@ define("route-recognizer",
         var state = solutions[0];
 
         if (state && state.handlers) {
+          // if a trailing slash was dropped and a star segment is the last segment 
+          // specified, put the trailing slash back
+          if (isSlashDropped && state.regex.source.slice(-5) === "(.+)$") {
+            path = path + "/";
+          }
           return findHandler(state, path, queryParams);
         }
       }
     };
 
-    __exports__['default'] = RouteRecognizer;
+    __exports__["default"] = RouteRecognizer;
 
     function Target(path, matcher, delegate) {
       this.path = path;

--- a/dist/route-recognizer.cjs.js
+++ b/dist/route-recognizer.cjs.js
@@ -429,7 +429,8 @@ RouteRecognizer.prototype = {
 
   recognize: function(path) {
     var states = [ this.rootState ],
-        pathLen, i, l, queryStart, queryParams = {};
+        pathLen, i, l, queryStart, queryParams = {}, 
+        isSlashDropped = false;
 
     queryStart = path.indexOf('?');
     if (queryStart !== -1) {
@@ -445,6 +446,7 @@ RouteRecognizer.prototype = {
     pathLen = path.length;
     if (pathLen > 1 && path.charAt(pathLen - 1) === "/") {
       path = path.substr(0, pathLen - 1);
+      isSlashDropped = true;
     }
 
     for (i=0, l=path.length; i<l; i++) {
@@ -464,12 +466,17 @@ RouteRecognizer.prototype = {
     var state = solutions[0];
 
     if (state && state.handlers) {
+      // if a trailing slash was dropped and a star segment is the last segment 
+      // specified, put the trailing slash back
+      if (isSlashDropped && state.regex.source.slice(-5) === "(.+)$") {
+        path = path + "/";
+      }
       return findHandler(state, path, queryParams);
     }
   }
 };
 
-exports['default'] = RouteRecognizer;
+exports["default"] = RouteRecognizer;
 
 function Target(path, matcher, delegate) {
   this.path = path;

--- a/dist/route-recognizer.js
+++ b/dist/route-recognizer.js
@@ -430,7 +430,8 @@
 
     recognize: function(path) {
       var states = [ this.rootState ],
-          pathLen, i, l, queryStart, queryParams = {};
+          pathLen, i, l, queryStart, queryParams = {}, 
+          isSlashDropped = false;
 
       queryStart = path.indexOf('?');
       if (queryStart !== -1) {
@@ -446,6 +447,7 @@
       pathLen = path.length;
       if (pathLen > 1 && path.charAt(pathLen - 1) === "/") {
         path = path.substr(0, pathLen - 1);
+        isSlashDropped = true;
       }
 
       for (i=0, l=path.length; i<l; i++) {
@@ -465,6 +467,11 @@
       var state = solutions[0];
 
       if (state && state.handlers) {
+        // if a trailing slash was dropped and a star segment is the last segment 
+        // specified, put the trailing slash back
+        if (isSlashDropped && state.regex.source.slice(-5) === "(.+)$") {
+          path = path + "/";
+        }
         return findHandler(state, path, queryParams);
       }
     }

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -428,7 +428,8 @@ RouteRecognizer.prototype = {
 
   recognize: function(path) {
     var states = [ this.rootState ],
-        pathLen, i, l, queryStart, queryParams = {};
+        pathLen, i, l, queryStart, queryParams = {}, 
+        isSlashDropped = false;
 
     queryStart = path.indexOf('?');
     if (queryStart !== -1) {
@@ -444,6 +445,7 @@ RouteRecognizer.prototype = {
     pathLen = path.length;
     if (pathLen > 1 && path.charAt(pathLen - 1) === "/") {
       path = path.substr(0, pathLen - 1);
+      isSlashDropped = true;
     }
 
     for (i=0, l=path.length; i<l; i++) {
@@ -463,6 +465,11 @@ RouteRecognizer.prototype = {
     var state = solutions[0];
 
     if (state && state.handlers) {
+      // if a trailing slash was dropped and a star segment is the last segment 
+      // specified, put the trailing slash back
+      if (isSlashDropped && state.regex.source.slice(-5) === "(.+)$") {
+        path = path + "/";
+      }
       return findHandler(state, path, queryParams);
     }
   }

--- a/tests/router-tests.js
+++ b/tests/router-tests.js
@@ -176,6 +176,40 @@ test("supports star routes", function() {
   });
 });
 
+test("star route does not swallow trailing `/`", function() {
+  var r;
+  
+  router.map(function(match) {
+    match("/").to("posts");
+    match("/*everything").to("glob");
+  });
+
+  r = "folder1/folder2/folder3/";
+  matchesRoute("/" + r, [{ handler: "glob", params: {everything: r}, isDynamic: true}]);
+});
+
+test("support star route before other segment", function() {
+  router.map(function(match) {
+    match("/*everything/:extra").to("glob");
+  });
+
+  ["folder1/folder2/folder3//the-extra-stuff/", "folder1/folder2/folder3//the-extra-stuff"].forEach(function(r) {
+    matchesRoute("/" + r, [{ handler: "glob", params: {everything: "folder1/folder2/folder3/", extra: "the-extra-stuff"}, isDynamic: true}]);  
+  });
+});
+
+test("support nested star route", function() {
+  router.map(function(match) {
+    match("/*everything").to("glob", function(match){
+      match("/:extra").to("extra");
+    });
+  });
+
+  ["folder1/folder2/folder3//the-extra-stuff/", "folder1/folder2/folder3//the-extra-stuff"].forEach(function(r) {
+    matchesRoute("/" + r, [{ handler: "glob", params: {everything: "folder1/folder2/folder3/"}, isDynamic: true}, { handler: "extra", params: {extra: "the-extra-stuff"}, isDynamic: true}]);
+  });
+});
+
 test("calls a delegate whenever a new context is entered", function() {
   var passedArguments = [];
 


### PR DESCRIPTION
For a route specified as 

```
/*everything
```

a URL of 

```
folder1/folder2/folder3/
```

would return 

```
params: { everything: "folder1/folder2/folder3" }
```

which is missing the trailing `/`. I was expecting the URL section matched to the star segment would be unmodified.

This PR checks if a star segment is present and if a slash was removed and will add the trailing slash back to the path.
