### PR TITLE
Give precedence to routes with more static segments.

### DIFF
--- a/dist/route-recognizer.amd.js
+++ b/dist/route-recognizer.amd.js
@@ -232,7 +232,7 @@ define("route-recognizer",
       return states.sort(function(a, b) {
         if (a.types.stars !== b.types.stars) { return a.types.stars - b.types.stars; }
         if (a.types.dynamics !== b.types.dynamics) { return a.types.dynamics - b.types.dynamics; }
-        if (a.types.statics !== b.types.statics) { return a.types.statics - b.types.statics; }
+        if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
 
         return 0;
       });

--- a/dist/route-recognizer.cjs.js
+++ b/dist/route-recognizer.cjs.js
@@ -229,7 +229,7 @@ function sortSolutions(states) {
   return states.sort(function(a, b) {
     if (a.types.stars !== b.types.stars) { return a.types.stars - b.types.stars; }
     if (a.types.dynamics !== b.types.dynamics) { return a.types.dynamics - b.types.dynamics; }
-    if (a.types.statics !== b.types.statics) { return a.types.statics - b.types.statics; }
+    if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
 
     return 0;
   });

--- a/dist/route-recognizer.js
+++ b/dist/route-recognizer.js
@@ -230,7 +230,7 @@
     return states.sort(function(a, b) {
       if (a.types.stars !== b.types.stars) { return a.types.stars - b.types.stars; }
       if (a.types.dynamics !== b.types.dynamics) { return a.types.dynamics - b.types.dynamics; }
-      if (a.types.statics !== b.types.statics) { return a.types.statics - b.types.statics; }
+      if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
 
       return 0;
     });

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -228,7 +228,7 @@ function sortSolutions(states) {
   return states.sort(function(a, b) {
     if (a.types.stars !== b.types.stars) { return a.types.stars - b.types.stars; }
     if (a.types.dynamics !== b.types.dynamics) { return a.types.dynamics - b.types.dynamics; }
-    if (a.types.statics !== b.types.statics) { return a.types.statics - b.types.statics; }
+    if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
 
     return 0;
   });

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -124,6 +124,18 @@ test("Overlapping routes recognize", function() {
   deepEqual(router.recognize("/foo/1"), [{ handler: handler2, params: { baz: "1" }, isDynamic: true }]);
 });
 
+test("Overlapping star routes recognize", function() {
+  var handler1 = { handler: 1 };
+  var handler2 = { handler: 2 };
+  var router = new RouteRecognizer();
+
+  router.add([{ path: "/foo/*bar", handler: handler2 }]);
+  router.add([{ path: "/*foo", handler: handler1 }]);
+
+  deepEqual(router.recognize("/foo/1"), [{ handler: handler2, params: { bar: "1" }, isDynamic: true }]);
+  deepEqual(router.recognize("/1"), [{ handler: handler1, params: { foo: "1" }, isDynamic: true }]);
+});
+
 test("Routes with trailing `/` recognize", function() {
   var handler = {};
   var router = new RouteRecognizer();


### PR DESCRIPTION
I might be missing something, but it seems to me that you'd always want to select the route with the most static segments if both stars and dynamics are equal.
