### PR TITLE
Upgrade to 0.3.x of es6-module-transpiler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .bundle/
 bundle
 bin/
+/node_modules

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 # A sample Gemfile
 source "https://rubygems.org"
 
-gem "js_module_transpiler", github: "wycats/js_module_transpiler", branch: "master"
 gem "rake"
 gem "qunit-cli-runner", github: "wagenet/qunit-cli-runner", branch: "master"
 gem "jshintrb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,6 @@ GIT
     qunit-cli-runner (0.0.1)
       colored
 
-GIT
-  remote: git://github.com/wycats/js_module_transpiler.git
-  revision: c9f0ada0f7b7ec654ddec25f4a1fb07bcf41c9f7
-  branch: master
-  specs:
-    js_module_transpiler (0.0.1)
-      thor
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -25,13 +17,11 @@ GEM
       rake
     multi_json (1.7.9)
     rake (10.0.2)
-    thor (0.16.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  js_module_transpiler!
   jshintrb
   qunit-cli-runner!
   rake

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ def replace_debug(file)
 end
 
 require "bundler/setup"
-require "js_module_transpiler"
+require File.expand_path("../tasks/support/js_module_transpiler", __FILE__)
 require "qunit-cli-runner"
 require "jshintrb/jshinttask"
 
@@ -31,7 +31,7 @@ def file_task(type)
     dsl = File.read("lib/dsl.js")
 
     open filename, "w" do |file|
-      converter = JsModuleTranspiler::Compiler.new("#{recognizer}\n#{dsl}", "route-recognizer")
+      converter = JsModuleTranspiler::Compiler.new("#{recognizer}\n#{dsl}", "route-recognizer", imports: {"__nothing" => "__nothing"})
       file.puts converter.send("to_#{type}")
     end
   end
@@ -43,7 +43,7 @@ def file_task(type)
     dsl = replace_debug("lib/dsl.js")
 
     open debug_filename, "w" do |file|
-      converter = JsModuleTranspiler::Compiler.new("#{recognizer}\n#{dsl}", "route-recognizer")
+      converter = JsModuleTranspiler::Compiler.new("#{recognizer}\n#{dsl}", "route-recognizer", imports: {"__nothing" => "__nothing"})
       file.puts converter.send("to_#{type}")
     end
   end

--- a/dist/route-recognizer.amd.js
+++ b/dist/route-recognizer.amd.js
@@ -1,6 +1,6 @@
-define("route-recognizer",
-  [],
-  function() {
+define("route-recognizer", 
+  ["exports"],
+  function(__exports__) {
     "use strict";
     var specials = [
       '/', '.', '*', '+', '?', '|',
@@ -472,6 +472,8 @@ define("route-recognizer",
       }
     };
 
+    __exports__['default'] = RouteRecognizer;
+
     function Target(path, matcher, delegate) {
       this.path = path;
       this.matcher = matcher;
@@ -589,5 +591,4 @@ define("route-recognizer",
         else { this.add(route); }
       }, this);
     };
-    return RouteRecognizer;
   });

--- a/dist/route-recognizer.cjs.js
+++ b/dist/route-recognizer.cjs.js
@@ -469,6 +469,8 @@ RouteRecognizer.prototype = {
   }
 };
 
+exports['default'] = RouteRecognizer;
+
 function Target(path, matcher, delegate) {
   this.path = path;
   this.matcher = matcher;
@@ -586,4 +588,3 @@ RouteRecognizer.prototype.map = function(callback, addRouteCallback) {
     else { this.add(route); }
   }, this);
 };
-module.exports = RouteRecognizer;

--- a/dist/route-recognizer.js
+++ b/dist/route-recognizer.js
@@ -1,4 +1,4 @@
-(function(exports) {
+(function(__exports__) {
   "use strict";
   var specials = [
     '/', '.', '*', '+', '?', '|',
@@ -470,6 +470,8 @@
     }
   };
 
+  __exports__.RouteRecognizer = RouteRecognizer;
+
   function Target(path, matcher, delegate) {
     this.path = path;
     this.matcher = matcher;
@@ -587,5 +589,4 @@
       else { this.add(route); }
     }, this);
   };
-  exports.RouteRecognizer = RouteRecognizer;
 })(window);

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -293,7 +293,6 @@ var RouteRecognizer = function() {
   this.names = {};
 };
 
-export = RouteRecognizer;
 
 RouteRecognizer.prototype = {
   add: function(routes, options) {
@@ -468,3 +467,5 @@ RouteRecognizer.prototype = {
     }
   }
 };
+
+export default RouteRecognizer;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "route-recognizer",
+  "version": "0.0.0",
+  "description": "A dummy package.json file for installing node_modules",
+  "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tildeio/route-recognizer.git"
+  },
+  "devDependencies": {
+    "es6-module-transpiler": "~0.3.2"
+  }
+}

--- a/tasks/support/js_module_transpiler.rb
+++ b/tasks/support/js_module_transpiler.rb
@@ -1,0 +1,71 @@
+# This is a shim that looks like the JsModuleTranspiler from
+# https://github.com/wycats/js_module_transpiler but uses the ES6 Module
+# Transpiler from https://github.com/square/es6-module-transpiler.
+module JsModuleTranspiler
+  class Compiler
+    def initialize(script, name, options={})
+      @script  = script
+      @name    = name
+      @options = options
+    end
+
+    def to_amd
+      transpile :amd
+    end
+
+    def to_cjs
+      transpile :cjs
+    end
+
+    def to_globals
+      transpile :globals
+    end
+
+    private
+
+    attr_reader :script, :name, :options
+
+    def transpile(type)
+      ensure_es6_transpiler_package_installed
+
+      args = [es6_transpiler_binary]
+      args << '--type' << type.to_s
+      args << '--stdio'
+
+      case type
+      when :globals
+        if options[:imports]
+          imports = options[:imports].map {|path,global| "#{path}:#{global}" }.join(',')
+          args << '--imports' << imports
+        end
+
+        if options[:into]
+          args << '--global' << options[:into]
+        end
+      when :amd
+        if name
+          args << '--module-name' << name
+        else
+          args << '--anonymous'
+        end
+      end
+
+      STDERR.puts args.join(' ')
+
+      IO.popen(args, 'w+') do |io|
+        io << script
+        io.close_write
+        return io.read
+      end
+    end
+
+    def ensure_es6_transpiler_package_installed
+      return if File.executable?(es6_transpiler_binary)
+      %x{npm install}
+    end
+
+    def es6_transpiler_binary
+      './node_modules/.bin/compile-modules'
+    end
+  end
+end


### PR DESCRIPTION
Note that 0.3.2 seems to have a bug with globals, in which it cannot build 
without at least one import named on the command line.  A nonsense import,
which is not actually used in the source, does not affect the output.

It is perfectly fine to remove `imports: {"__nothing" => "__nothing"}` for a 
version of the es6-module-transpiler that does not suffer from this problem.

cc @machty
