### PR TITLE
Make route-recognizer requireable in nodejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "https://github.com/tildeio/route-recognizer.git"
   },
+  "main": "dist/route-recognizer.cjs.js",
   "devDependencies": {
     "es6-module-transpiler": "~0.3.2"
   }


### PR DESCRIPTION
While one can install route-recognizer using npm it is not possible to require it using `require('route-recognizer')`. This can be fixed by specifying a "main" file in `package.json`.

While this makes route-recognizer requireable, it is still exported to `module.exports.default` which is weird because this forces me to use `var RouteRecognizer = require('route-recognizer')['default']`. But since I don't understand the build system enough I can't fix that. (BTW the same applies to the AMD module)
