### PR TITLE
Prepare for publishing to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+Gemfile
+Gemfile.lock
+Rakefile
+tasks

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "route-recognizer",
-  "version": "0.0.0",
-  "description": "A dummy package.json file for installing node_modules",
+  "version": "0.1.0",
+  "description": "A lightweight JavaScript library that matches paths against registered routes.",
   "author": "",
   "repository": {
     "type": "git",
@@ -9,5 +9,6 @@
   },
   "devDependencies": {
     "es6-module-transpiler": "~0.3.2"
-  }
+  },
+  "main": "dist/route-recognizer.cjs.js"
 }


### PR DESCRIPTION
This PR is one step in addressing https://github.com/tildeio/router.js/issues/69. For `router.js` to exist on NPM, its dependencies should first exist on NPM. These small changes prepare this library for publishing to NPM.
- Update `package.json`:
  - Add `main` field, pointing to CommonJS build at `dist/route-recognizer.cjs.js`.
  - Update description.
  - Add version -- I chose `0.1.0` but perhaps it should be different.
- Add `.npmignore`, ignoring Ruby build files.
