### PR TITLE
[QueryParams] Support for Arrays

### DIFF
--- a/dist/route-recognizer.amd.js
+++ b/dist/route-recognizer.amd.js
@@ -403,10 +403,18 @@ define("route-recognizer",
               continue;
             }
             var pair = key;
-            if(value !== true) {
-              pair += "=" + encodeURIComponent(value);
+            if (Array.isArray(value)) {
+              for (var i = 0, l = value.length; i < l; i++) {
+                var arrayPair = key + '[]' + '=' + encodeURIComponent(value[i]);
+                pairs.push(arrayPair);
+              }
             }
-            pairs.push(pair);
+            else if (value !== true) {
+              pair += "=" + encodeURIComponent(value);
+              pairs.push(pair);
+            } else {
+              pairs.push(pair);
+            }
           }
         }
 
@@ -420,15 +428,28 @@ define("route-recognizer",
         for(var i=0; i < pairs.length; i++) {
           var pair      = pairs[i].split('='),
               key       = decodeURIComponent(pair[0]),
+              keyLength = key.length,
+              isArray = false,
               value;
-
           if (pair.length === 1) {
             value = true;
           } else {
+            //Handle arrays
+            if (keyLength > 2 && key.slice(keyLength -2) === '[]') {
+              isArray = true;
+              key = key.slice(0, keyLength - 2);
+              if(!queryParams[key]) {
+                queryParams[key] = [];
+              }
+            }
             value = pair[1] ? decodeURIComponent(pair[1]) : '';
           }
-
-          queryParams[key] = value;
+          if (isArray) {
+            queryParams[key].push(value);
+          } else {
+            queryParams[key] = value;
+          }
+          
         }
         return queryParams;
       },

--- a/dist/route-recognizer.cjs.js
+++ b/dist/route-recognizer.cjs.js
@@ -400,10 +400,18 @@ RouteRecognizer.prototype = {
           continue;
         }
         var pair = key;
-        if(value !== true) {
-          pair += "=" + encodeURIComponent(value);
+        if (Array.isArray(value)) {
+          for (var i = 0, l = value.length; i < l; i++) {
+            var arrayPair = key + '[]' + '=' + encodeURIComponent(value[i]);
+            pairs.push(arrayPair);
+          }
         }
-        pairs.push(pair);
+        else if (value !== true) {
+          pair += "=" + encodeURIComponent(value);
+          pairs.push(pair);
+        } else {
+          pairs.push(pair);
+        }
       }
     }
 
@@ -417,15 +425,28 @@ RouteRecognizer.prototype = {
     for(var i=0; i < pairs.length; i++) {
       var pair      = pairs[i].split('='),
           key       = decodeURIComponent(pair[0]),
+          keyLength = key.length,
+          isArray = false,
           value;
-
       if (pair.length === 1) {
         value = true;
       } else {
+        //Handle arrays
+        if (keyLength > 2 && key.slice(keyLength -2) === '[]') {
+          isArray = true;
+          key = key.slice(0, keyLength - 2);
+          if(!queryParams[key]) {
+            queryParams[key] = [];
+          }
+        }
         value = pair[1] ? decodeURIComponent(pair[1]) : '';
       }
-
-      queryParams[key] = value;
+      if (isArray) {
+        queryParams[key].push(value);
+      } else {
+        queryParams[key] = value;
+      }
+      
     }
     return queryParams;
   },

--- a/dist/route-recognizer.js
+++ b/dist/route-recognizer.js
@@ -401,10 +401,18 @@
             continue;
           }
           var pair = key;
-          if(value !== true) {
-            pair += "=" + encodeURIComponent(value);
+          if (Array.isArray(value)) {
+            for (var i = 0, l = value.length; i < l; i++) {
+              var arrayPair = key + '[]' + '=' + encodeURIComponent(value[i]);
+              pairs.push(arrayPair);
+            }
           }
-          pairs.push(pair);
+          else if (value !== true) {
+            pair += "=" + encodeURIComponent(value);
+            pairs.push(pair);
+          } else {
+            pairs.push(pair);
+          }
         }
       }
 
@@ -418,15 +426,28 @@
       for(var i=0; i < pairs.length; i++) {
         var pair      = pairs[i].split('='),
             key       = decodeURIComponent(pair[0]),
+            keyLength = key.length,
+            isArray = false,
             value;
-
         if (pair.length === 1) {
           value = true;
         } else {
+          //Handle arrays
+          if (keyLength > 2 && key.slice(keyLength -2) === '[]') {
+            isArray = true;
+            key = key.slice(0, keyLength - 2);
+            if(!queryParams[key]) {
+              queryParams[key] = [];
+            }
+          }
           value = pair[1] ? decodeURIComponent(pair[1]) : '';
         }
-
-        queryParams[key] = value;
+        if (isArray) {
+          queryParams[key].push(value);
+        } else {
+          queryParams[key] = value;
+        }
+        
       }
       return queryParams;
     },

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -399,10 +399,18 @@ RouteRecognizer.prototype = {
           continue;
         }
         var pair = key;
-        if(value !== true) {
-          pair += "=" + encodeURIComponent(value);
+        if (Array.isArray(value)) {
+          for (var i = 0, l = value.length; i < l; i++) {
+            var arrayPair = key + '[]' + '=' + encodeURIComponent(value[i]);
+            pairs.push(arrayPair);
+          }
         }
-        pairs.push(pair);
+        else if (value !== true) {
+          pair += "=" + encodeURIComponent(value);
+          pairs.push(pair);
+        } else {
+          pairs.push(pair);
+        }
       }
     }
 
@@ -416,15 +424,28 @@ RouteRecognizer.prototype = {
     for(var i=0; i < pairs.length; i++) {
       var pair      = pairs[i].split('='),
           key       = decodeURIComponent(pair[0]),
+          keyLength = key.length,
+          isArray = false,
           value;
-
       if (pair.length === 1) {
         value = true;
       } else {
+        //Handle arrays
+        if (keyLength > 2 && key.slice(keyLength -2) === '[]') {
+          isArray = true;
+          key = key.slice(0, keyLength - 2);
+          if(!queryParams[key]) {
+            queryParams[key] = [];
+          }
+        }
         value = pair[1] ? decodeURIComponent(pair[1]) : '';
       }
-
-      queryParams[key] = value;
+      if (isArray) {
+        queryParams[key].push(value);
+      } else {
+        queryParams[key] = value;
+      }
+      
     }
     return queryParams;
   },


### PR DESCRIPTION
This adds basic support for Arrays.

The following URL: /?foo[]=1&foo[]=2 will generate:
`{foo: ["1", "2"]}` and vice versa.
