### PR TITLE
sortSolutions: prefer more dynamics if any stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,9 @@ result3 === [{ handler: newPost, params: {} }];
 
 As you can see, this has the expected result. Explicit
 static paths match more closely than dynamic paths.
+
+This is also true when comparing star segments and other
+dynamic segments. The recognizer will prefer fewer star
+segments and prefer using them for less of the match (and,
+consequently, using dynamic and static segments for more
+of the match).

--- a/dist/route-recognizer.amd.js
+++ b/dist/route-recognizer.amd.js
@@ -227,10 +227,24 @@ define("route-recognizer",
     END IF **/
 
     // This is a somewhat naive strategy, but should work in a lot of cases
-    // A better strategy would properly resolve /posts/:id/new and /posts/edit/:id
+    // A better strategy would properly resolve /posts/:id/new and /posts/edit/:id.
+    //
+    // This strategy generally prefers more static and less dynamic matching.
+    // Specifically, it
+    //
+    //  * prefers fewer stars to more, then
+    //  * prefers using stars for less of the match to more, then
+    //  * prefers fewer dynamic segments to more, then
+    //  * prefers more static segments to more
     function sortSolutions(states) {
       return states.sort(function(a, b) {
         if (a.types.stars !== b.types.stars) { return a.types.stars - b.types.stars; }
+
+        if (a.types.stars) {
+          if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
+          if (a.types.dynamics !== b.types.dynamics) { return b.types.dynamics - a.types.dynamics; }
+        }
+
         if (a.types.dynamics !== b.types.dynamics) { return a.types.dynamics - b.types.dynamics; }
         if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
 

--- a/dist/route-recognizer.cjs.js
+++ b/dist/route-recognizer.cjs.js
@@ -224,10 +224,24 @@ function debugState(state) {
 END IF **/
 
 // This is a somewhat naive strategy, but should work in a lot of cases
-// A better strategy would properly resolve /posts/:id/new and /posts/edit/:id
+// A better strategy would properly resolve /posts/:id/new and /posts/edit/:id.
+//
+// This strategy generally prefers more static and less dynamic matching.
+// Specifically, it
+//
+//  * prefers fewer stars to more, then
+//  * prefers using stars for less of the match to more, then
+//  * prefers fewer dynamic segments to more, then
+//  * prefers more static segments to more
 function sortSolutions(states) {
   return states.sort(function(a, b) {
     if (a.types.stars !== b.types.stars) { return a.types.stars - b.types.stars; }
+
+    if (a.types.stars) {
+      if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
+      if (a.types.dynamics !== b.types.dynamics) { return b.types.dynamics - a.types.dynamics; }
+    }
+
     if (a.types.dynamics !== b.types.dynamics) { return a.types.dynamics - b.types.dynamics; }
     if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
 

--- a/dist/route-recognizer.js
+++ b/dist/route-recognizer.js
@@ -225,10 +225,24 @@
   END IF **/
 
   // This is a somewhat naive strategy, but should work in a lot of cases
-  // A better strategy would properly resolve /posts/:id/new and /posts/edit/:id
+  // A better strategy would properly resolve /posts/:id/new and /posts/edit/:id.
+  //
+  // This strategy generally prefers more static and less dynamic matching.
+  // Specifically, it
+  //
+  //  * prefers fewer stars to more, then
+  //  * prefers using stars for less of the match to more, then
+  //  * prefers fewer dynamic segments to more, then
+  //  * prefers more static segments to more
   function sortSolutions(states) {
     return states.sort(function(a, b) {
       if (a.types.stars !== b.types.stars) { return a.types.stars - b.types.stars; }
+
+      if (a.types.stars) {
+        if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
+        if (a.types.dynamics !== b.types.dynamics) { return b.types.dynamics - a.types.dynamics; }
+      }
+
       if (a.types.dynamics !== b.types.dynamics) { return a.types.dynamics - b.types.dynamics; }
       if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
 

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -223,10 +223,24 @@ function debugState(state) {
 END IF **/
 
 // This is a somewhat naive strategy, but should work in a lot of cases
-// A better strategy would properly resolve /posts/:id/new and /posts/edit/:id
+// A better strategy would properly resolve /posts/:id/new and /posts/edit/:id.
+//
+// This strategy generally prefers more static and less dynamic matching.
+// Specifically, it
+//
+//  * prefers fewer stars to more, then
+//  * prefers using stars for less of the match to more, then
+//  * prefers fewer dynamic segments to more, then
+//  * prefers more static segments to more
 function sortSolutions(states) {
   return states.sort(function(a, b) {
     if (a.types.stars !== b.types.stars) { return a.types.stars - b.types.stars; }
+
+    if (a.types.stars) {
+      if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
+      if (a.types.dynamics !== b.types.dynamics) { return b.types.dynamics - a.types.dynamics; }
+    }
+
     if (a.types.dynamics !== b.types.dynamics) { return a.types.dynamics - b.types.dynamics; }
     if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
 

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -172,6 +172,19 @@ test("Overlapping star routes recognize", function() {
   resultsMatch(router.recognize("/1"), [{ handler: handler1, params: { foo: "1" }, isDynamic: true }]);
 });
 
+test("Prefers single dynamic segments over stars", function() {
+  var handler1 = { handler: 1 };
+  var handler2 = { handler: 2 };
+  var router = new RouteRecognizer();
+
+  router.add([{ path: "/foo/*star", handler: handler1 }]);
+  router.add([{ path: "/foo/*star/:dynamic", handler: handler2 }]);
+
+  resultsMatch(router.recognize("/foo/1"), [{ handler: handler1, params: { star: "1" }, isDynamic: true }]);
+  resultsMatch(router.recognize("/foo/suffix"), [{ handler: handler1, params: { star: "suffix" }, isDynamic: true }]);
+  resultsMatch(router.recognize("/foo/bar/suffix"), [{ handler: handler2, params: { star: "bar", dynamic: "suffix" }, isDynamic: true }]);
+});
+
 test("Routes with trailing `/` recognize", function() {
   var handler = {};
   var router = new RouteRecognizer();


### PR DESCRIPTION
When sorting States
1. prefer fewer stars to more stars
2. if any stars, prefer more dynamics and statics to fewer (since those both eat away at the amount that the stars must take up)
3. if no stars, prefer fewer dynamics and more statics

This changes the rule slightly to: "prefer fewer dynamic segments and prefer using them for less of the match".

Fixes #21
