### PR TITLE
Encode key when generating query string

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -423,7 +423,7 @@ RouteRecognizer.prototype = {
       if (value == null) {
         continue;
       }
-      var pair = key;
+      var pair = encodeURIComponent(key);
       if (isArray(value)) {
         for (var j = 0, l = value.length; j < l; j++) {
           var arrayPair = key + '[]' + '=' + encodeURIComponent(value[j]);

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -330,6 +330,11 @@ test("Generation works", function() {
   equal( router.generate("postIndex"), "/posts" );
 });
 
+test("Parsing and generation results into the same input string", function() {
+  var query = "filter%20data=date";
+  equal(router.generateQueryString(router.parseQueryString(query)), '?' + query);
+});
+
 test("Generation works with query params", function() {
   equal( router.generate("index", {queryParams: {filter: 'date'}}), "/?filter=date" );
   equal( router.generate("index", {queryParams: {filter: true}}), "/?filter=true" );


### PR DESCRIPTION
The key is decoded during the parsing of the query string, but not when it is encoded.
