### PR TITLE
Accept '%' encoded in the values of query strings

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -477,14 +477,14 @@ RouteRecognizer.prototype = {
         pathLen, i, l, queryStart, queryParams = {},
         isSlashDropped = false;
 
-    path = decodeURI(path);
-
     queryStart = path.indexOf('?');
     if (queryStart !== -1) {
       var queryString = path.substr(queryStart + 1, path.length);
       path = path.substr(0, queryStart);
       queryParams = this.parseQueryString(queryString);
     }
+
+    path = decodeURI(path);
 
     // DEBUG GROUP path
 

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -84,6 +84,14 @@ test("A simple route with multiple query params recognizes", function() {
   deepEqual(router.recognize("/foo/bar?other=something").queryParams, { other: 'something' });
 });
 
+test("A simple route with query params with encoding recognizes", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/foo/bar", handler: handler}]);
+
+  deepEqual(router.recognize("/foo/bar?other=something%20100%25").queryParams, { other: 'something 100%' });
+});
+
 
 test("A `/` route recognizes", function() {
   var handler = {};


### PR DESCRIPTION
When encoding a % in a query string, RouteRecognizer.prototype.recognize encodes the value 2 times, leading to an error. This was reported here: https://github.com/emberjs/ember.js/issues/4998
