### PR TITLE
Bumped to ember-cli@v0.1.7 to fix npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "broccoli-jshint": "~0.5.1",
     "broccoli-replace": "~0.1.6",
     "broccoli-merge-trees": "^0.2.1",
-    "ember-cli": "0.0.40"
+    "ember-cli": "0.1.7"
   },
   "main": "dist/route-recognizer.js",
   "bugs": {


### PR DESCRIPTION
I actually can't even `npm install` this project right now as-is because `v0.0.40` contained an `expresss` typo [found here](https://github.com/ember-cli/ember-cli/blob/v0.0.40/package.json#L58).

```bash
npm ERR! 404 Not Found: expresss
npm ERR! 404
npm ERR! 404 'expresss' is not in the npm registry.
```

It also doesn't hurt to bump it too :trophy: 