### PR TITLE
[BUGFIX] Query param plus symbols (+) are now transformed to spaces

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -311,6 +311,12 @@ function addSegment(currentState, segment) {
   return currentState;
 }
 
+function decodeQueryParamPart(part) {
+  // http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1
+  part = part.replace(/\+/gm, '%20');
+  return decodeURIComponent(part);
+}
+
 // The main interface
 
 var RouteRecognizer = function() {
@@ -446,7 +452,7 @@ RouteRecognizer.prototype = {
     var pairs = queryString.split("&"), queryParams = {};
     for(var i=0; i < pairs.length; i++) {
       var pair      = pairs[i].split('='),
-          key       = decodeURIComponent(pair[0]),
+          key       = decodeQueryParamPart(pair[0]),
           keyLength = key.length,
           isArray = false,
           value;
@@ -461,7 +467,7 @@ RouteRecognizer.prototype = {
             queryParams[key] = [];
           }
         }
-        value = pair[1] ? decodeURIComponent(pair[1]) : '';
+        value = pair[1] ? decodeQueryParamPart(pair[1]) : '';
       }
       if (isArray) {
         queryParams[key].push(value);

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -94,6 +94,14 @@ test("A simple route with query params with encoding recognizes", function() {
   deepEqual(router.recognize("/foo/bar?other=something%20100%25").queryParams, { other: 'something 100%' });
 });
 
+test("A route with query params with pluses for spaces instead of %20 recognizes", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/foo/bar", handler: handler}]);
+
+  deepEqual(router.recognize("/foo/bar?++one+two=three+four+five++").queryParams, { '  one two': 'three four five  ' });
+});
+
 
 test("A `/` route recognizes", function() {
   var handler = {};


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/10190

http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1

Facebook's share redirect masking is a great way to confirm this issue and behavior. (note that even query keys can have encoded spaces)

Cc/ @machty 