### PR TITLE
proper fallback for module check

### DIFF
--- a/dist/route-recognizer.js
+++ b/dist/route-recognizer.js
@@ -638,7 +638,7 @@
     /* global define:true module:true window: true */
     if (typeof define === 'function' && define['amd']) {
       define(function() { return $$route$recognizer$$default; });
-    } else if (typeof module !== 'undefined' && module['exports']) {
+    } else if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
       module['exports'] = $$route$recognizer$$default;
     } else if (typeof this !== 'undefined') {
       this['RouteRecognizer'] = $$route$recognizer$$default;

--- a/lib/route-recognizer.umd.js
+++ b/lib/route-recognizer.umd.js
@@ -3,7 +3,7 @@ import RouteRecognizer from './route-recognizer';
 /* global define:true module:true window: true */
 if (typeof define === 'function' && define['amd']) {
   define(function() { return RouteRecognizer; });
-} else if (typeof module !== 'undefined' && module['exports']) {
+} else if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
   module['exports'] = RouteRecognizer;
 } else if (typeof this !== 'undefined') {
   this['RouteRecognizer'] = RouteRecognizer;


### PR DESCRIPTION
We've had problems with Qunit having a global "module.require", so the route-recognizer thought we would use modules, instead of the window namespace.

This check fixes that assumption. If I'm on the wrong path here, I'm glad to be told why I'm wrong.