### PR TITLE
Stop the Ember CLI from asking for the source map

### DIFF
--- a/dist/route-recognizer.js
+++ b/dist/route-recognizer.js
@@ -644,5 +644,3 @@
       this['RouteRecognizer'] = $$route$recognizer$$default;
     }
 }).call(this);
-
-//# sourceMappingURL=route-recognizer.js.map


### PR DESCRIPTION
Temporary fix for Issue #44, which is that the Ember CLI complains that it needs a source map that it can't find.