### PR TITLE
add name parameter to amd define function call

### DIFF
--- a/dist/route-recognizer.js
+++ b/dist/route-recognizer.js
@@ -637,7 +637,7 @@
 
     /* global define:true module:true window: true */
     if (typeof define === 'function' && define['amd']) {
-      define(function() { return $$route$recognizer$$default; });
+      define('route-recognizer', function() { return $$route$recognizer$$default; });
     } else if (typeof module !== 'undefined' && module['exports']) {
       module['exports'] = $$route$recognizer$$default;
     } else if (typeof this !== 'undefined') {


### PR DESCRIPTION
Loader like almond needs the name to be passed for to the define function.