### PR TITLE
add name parameter to amd define function call

### DIFF
--- a/lib/route-recognizer.umd.js
+++ b/lib/route-recognizer.umd.js
@@ -2,7 +2,7 @@ import RouteRecognizer from './route-recognizer';
 
 /* global define:true module:true window: true */
 if (typeof define === 'function' && define['amd']) {
-  define(function() { return RouteRecognizer; });
+  define('route-recognizer', function() { return RouteRecognizer; });
 } else if (typeof module !== 'undefined' && module['exports']) {
   module['exports'] = RouteRecognizer;
 } else if (typeof this !== 'undefined') {


### PR DESCRIPTION
Loader like almond needs the name to be passed for to the define function.
This is related to #49