### PR TITLE
encode and decode path segments in urls when generating and recognizing, respectively

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -500,7 +500,11 @@ RouteRecognizer.prototype = {
       queryParams = this.parseQueryString(queryString);
     }
 
-    path = normalizePath(path);
+    if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS) {
+      path = normalizePath(path);
+    } else {
+      path = decodeURI(path);
+    }
 
     if (path.charAt(0) !== "/") { path = "/" + path; }
 

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -1,4 +1,8 @@
 import map from './route-recognizer/dsl';
+import Normalizer from './route-recognizer/normalizer';
+
+var normalizeRoute = Normalizer.normalizeRoute;
+var normalizePath = Normalizer.normalizePath;
 
 var specials = [
   '/', '.', '*', '+', '?', '|',
@@ -9,51 +13,6 @@ var escapeRegex = new RegExp('(\\' + specials.join('|\\') + ')', 'g');
 
 function isArray(test) {
   return Object.prototype.toString.call(test) === "[object Array]";
-}
-
-// According to RFC 3986 the following unreserved chars should never be
-// uri-encoded:
-// ALPHA / DIGIT / "-" / "." / "_" / "~"
-// See https://tools.ietf.org/html/rfc3986#section-2.3
-var uriUnreservedCharsRegex = /^[a-zA-Z0-9-._~]+$/;
-
-var hex2DigitRegex = /^[a-fA-F0-9]{2}$/;
-
-function isProbablyURIEncoded(string) {
-  var index = string.indexOf('%');
-
-  // If there is no %, the string is not uri-encoded
-  if (index === -1) {
-    return false;
-  }
-
-  while (index !== -1) {
-    var nextChars = string.slice(index + 1, index + 3);
-    if (!hex2DigitRegex.test(nextChars)) {
-      // % not followed by 2 hex chars is not uri-encoded
-      return false;
-    } else {
-      // % HEX HEX that encodes an unreserved char indicates
-      // a '%' that just happened to be followed by 2 hex digits,
-      // not a deliberately encoded sequence.
-      var ch = String.fromCharCode(parseInt(nextChars, 16));
-      if (uriUnreservedCharsRegex.test(ch)) {
-        return false;
-      }
-    }
-
-    index = string.indexOf('%', index + 3);
-  }
-
-  return true;
-}
-
-function stringNeedsEncoding(string) {
-  if (uriUnreservedCharsRegex.test(string)) {
-    return false;
-  } else {
-    return !isProbablyURIEncoded(string);
-  }
 }
 
 // A Segment represents a segment in the original route description.
@@ -73,15 +32,7 @@ function stringNeedsEncoding(string) {
 // * `invalidChars`: a String with a list of all invalid characters
 // * `repeat`: true if the character specification can repeat
 
-function StaticSegment(string) {
-  if (stringNeedsEncoding(string)) {
-    // If the string contains characters that should be uri-encoded, store
-    // the encoded form of the string because the router will recognize using
-    // uri-encoded paths
-    string = encodeURI(string);
-  }
-  this.string = string;
-}
+function StaticSegment(string) { this.string = string; }
 StaticSegment.prototype = {
   eachChar: function(currentState) {
     var string = this.string, ch;
@@ -151,6 +102,7 @@ function parse(route, names, specificity) {
   // also normalize.
   if (route.charAt(0) === "/") { route = route.substr(1); }
 
+  route = normalizeRoute(route);
   var segments = route.split("/");
   var results = new Array(segments.length);
 
@@ -342,7 +294,12 @@ function findHandler(state, path, queryParams) {
 
     for (var j=0; j<names.length; j++) {
       if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS) {
-        params[names[j]] = decodeURIComponent(captures[currentCapture++]);
+        // Don't decode a glob capture
+        if (state.hasGlob && currentCapture === (captures.length - 1)) {
+          params[names[j]] = captures[currentCapture++];
+        } else {
+          params[names[j]] = decodeURIComponent(captures[currentCapture++]);
+        }
       } else {
         params[names[j]] = captures[currentCapture++];
       }
@@ -401,6 +358,10 @@ RouteRecognizer.prototype = {
         // Add a representation of the segment to the NFA and regex
         currentState = segment.eachChar(currentState);
         regex += segment.regex();
+
+        if (segment instanceof StarSegment) {
+          currentState.hasGlob = true;
+        }
       }
       var handler = { handler: route.handler, names: names };
       handlers[i] = handler;
@@ -538,6 +499,8 @@ RouteRecognizer.prototype = {
       path = path.substr(0, queryStart);
       queryParams = this.parseQueryString(queryString);
     }
+
+    path = normalizePath(path);
 
     if (path.charAt(0) !== "/") { path = "/" + path; }
 

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -61,7 +61,7 @@ DynamicSegment.prototype = {
   },
 
   generate: function(params) {
-    return params[this.name];
+    return encodeURIComponent(params[this.name]);
   }
 };
 

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -11,6 +11,51 @@ function isArray(test) {
   return Object.prototype.toString.call(test) === "[object Array]";
 }
 
+// According to RFC 3986 the following unreserved chars should never be
+// uri-encoded:
+// ALPHA / DIGIT / "-" / "." / "_" / "~"
+// See https://tools.ietf.org/html/rfc3986#section-2.3
+var uriUnreservedCharsRegex = /^[a-zA-Z0-9-._~]+$/;
+
+var hex2DigitRegex = /^[a-fA-F0-9]{2}$/;
+
+function isProbablyURIEncoded(string) {
+  var index = string.indexOf('%');
+
+  // If there is no %, the string is not uri-encoded
+  if (index === -1) {
+    return false;
+  }
+
+  while (index !== -1) {
+    var nextChars = string.slice(index + 1, index + 3);
+    if (!hex2DigitRegex.test(nextChars)) {
+      // % not followed by 2 hex chars is not uri-encoded
+      return false;
+    } else {
+      // % HEX HEX that encodes an unreserved char indicates
+      // a '%' that just happened to be followed by 2 hex digits,
+      // not a deliberately encoded sequence.
+      var ch = String.fromCharCode(parseInt(nextChars, 16));
+      if (uriUnreservedCharsRegex.test(ch)) {
+        return false;
+      }
+    }
+
+    index = string.indexOf('%', index + 3);
+  }
+
+  return true;
+}
+
+function stringNeedsEncoding(string) {
+  if (uriUnreservedCharsRegex.test(string)) {
+    return false;
+  } else {
+    return !isProbablyURIEncoded(string);
+  }
+}
+
 // A Segment represents a segment in the original route description.
 // Each Segment type provides an `eachChar` and `regex` method.
 //
@@ -28,7 +73,15 @@ function isArray(test) {
 // * `invalidChars`: a String with a list of all invalid characters
 // * `repeat`: true if the character specification can repeat
 
-function StaticSegment(string) { this.string = string; }
+function StaticSegment(string) {
+  if (stringNeedsEncoding(string)) {
+    // If the string contains characters that should be uri-encoded, store
+    // the encoded form of the string because the router will recognize using
+    // uri-encoded paths
+    string = encodeURI(string);
+  }
+  this.string = string;
+}
 StaticSegment.prototype = {
   eachChar: function(currentState) {
     var string = this.string, ch;
@@ -485,8 +538,6 @@ RouteRecognizer.prototype = {
       path = path.substr(0, queryStart);
       queryParams = this.parseQueryString(queryString);
     }
-
-    path = decodeURI(path);
 
     if (path.charAt(0) !== "/") { path = "/" + path; }
 

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -284,7 +284,7 @@ function findHandler(state, path, queryParams) {
     var handler = handlers[i], names = handler.names, params = {};
 
     for (var j=0; j<names.length; j++) {
-      params[names[j]] = captures[currentCapture++];
+      params[names[j]] = decodeURIComponent(captures[currentCapture++]);
     }
 
     result[i] = { handler: handler.handler, params: params, isDynamic: !!names.length };

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -176,6 +176,7 @@ function State(charSpec) {
   this.regex = undefined;
   this.handlers = undefined;
   this.specificity = undefined;
+  this.hasStar = false;
 }
 
 State.prototype = {
@@ -294,8 +295,8 @@ function findHandler(state, path, queryParams) {
 
     for (var j=0; j<names.length; j++) {
       if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS) {
-        // Don't decode a glob capture
-        if (state.hasGlob && currentCapture === (captures.length - 1)) {
+        // Never decode the star segment glob capture
+        if (state.hasStar && currentCapture === (captures.length - 1)) {
           params[names[j]] = captures[currentCapture++];
         } else {
           params[names[j]] = decodeURIComponent(captures[currentCapture++]);
@@ -359,8 +360,9 @@ RouteRecognizer.prototype = {
         currentState = segment.eachChar(currentState);
         regex += segment.regex();
 
-        if (segment instanceof StarSegment) {
-          currentState.hasGlob = true;
+        // Mark the state as having a starSegment if the last segment is a star segment
+        if (segment instanceof StarSegment && j === segments.length - 1) {
+          currentState.hasStar = true;
         }
       }
       var handler = { handler: route.handler, names: names };

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -61,7 +61,11 @@ DynamicSegment.prototype = {
   },
 
   generate: function(params) {
-    return encodeURIComponent(params[this.name]);
+    if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS) {
+      return encodeURIComponent(params[this.name]);
+    } else {
+      return params[this.name];
+    }
   }
 };
 
@@ -284,7 +288,11 @@ function findHandler(state, path, queryParams) {
     var handler = handlers[i], names = handler.names, params = {};
 
     for (var j=0; j<names.length; j++) {
-      params[names[j]] = decodeURIComponent(captures[currentCapture++]);
+      if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS) {
+        params[names[j]] = decodeURIComponent(captures[currentCapture++]);
+      } else {
+        params[names[j]] = captures[currentCapture++];
+      }
     }
 
     result[i] = { handler: handler.handler, params: params, isDynamic: !!names.length };
@@ -516,5 +524,9 @@ RouteRecognizer.prototype = {
 RouteRecognizer.prototype.map = map;
 
 RouteRecognizer.VERSION = 'VERSION_STRING_PLACEHOLDER';
+
+// Set to false to opt-out of encoding and decoding path segments.
+// See https://github.com/tildeio/route-recognizer/pull/55
+RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = true;
 
 export default RouteRecognizer;

--- a/lib/route-recognizer/normalizer.js
+++ b/lib/route-recognizer/normalizer.js
@@ -22,14 +22,14 @@ function decodeURIWithoutPercents(string) {
 // values that are not reserved (like unicode characters).
 // Safe to call multiple times on the same path.
 function normalizePath(path) {
-  return percentEncodedValuesToUpper(decodeURIWithoutPercents(path));
+  return decodeURIWithoutPercents(percentEncodedValuesToUpper(path));
 }
 
 // Normalizes percent-encoded values to upper-case and decodes percent-encoded
 // values that are not reserved (like unicode characters).
 // Safe to call multiple times on the same route.
 function normalizeRoute(route) {
-  return percentEncodedValuesToUpper(decodeURIWithoutPercents(route));
+  return decodeURIWithoutPercents(percentEncodedValuesToUpper(route));
 }
 
 var Normalizer = {

--- a/lib/route-recognizer/normalizer.js
+++ b/lib/route-recognizer/normalizer.js
@@ -13,9 +13,9 @@ function percentEncodedValuesToUpper(string) {
 }
 
 function decodeURIWithoutPercents(string) {
-  return string.split(percentEncodedPercent).map(function(part) {
-    return decodeURI(part);
-  }).join(percentEncodedPercent);
+  return string.split(percentEncodedPercent)
+               .map(decodeURI)
+               .join(percentEncodedPercent);
 }
 
 // Normalizes percent-encoded values to upper-case and decodes percent-encoded

--- a/lib/route-recognizer/normalizer.js
+++ b/lib/route-recognizer/normalizer.js
@@ -1,0 +1,74 @@
+
+// Matches all percent-encoded values like %25
+var percentEncodedValueRegex = /%[a-fA-F0-9]{2}/g;
+
+// The percent-encoding for the percent "%" character
+var percentEncodedPercent = "%25";
+
+var percentRegex = new RegExp(percentEncodedPercent, "g");
+
+function toUpper(str) { return str.toUpperCase(); }
+
+// Turns all percent-encoded values to upper case
+// "%3a" -> "%3A"
+function percentEncodedValuesToUpper(string) {
+  return string.replace(percentEncodedValueRegex, toUpper);
+}
+
+function generateRandomString() {
+  return "_" + Math.floor(Math.random() * 1028).toString(16) + "_";
+}
+
+// Returns a sub string that does not occur in `string`
+function uniqueString(string) {
+  var random = generateRandomString();
+  while (string.indexOf(random) !== -1) {
+    random = generateRandomString();
+  }
+  return random;
+}
+
+// Replaces encoded percents ("%25") in string with a unique replacement value,
+// yields the string to the callback, and then replaces the replacement value
+// with encoded percents again before returning.
+// This is to work around the fact that `decodeURI` decodes "%25" -> "%" and is
+// therefore not safe to call multiple times on the same string.
+function replaceEncodedPercents(string, callback) {
+  var hasPercent = percentRegex.test(string);
+  var replacer;
+  if (hasPercent) {
+    replacer = uniqueString(string);
+    string = string.replace(percentRegex, replacer);
+  }
+  string = callback(string);
+  if (hasPercent) {
+    string = string.replace(new RegExp(replacer, "g"), percentEncodedPercent);
+  }
+
+  return string;
+}
+
+// Normalizes percent-encoded values to upper-case and decodes percent-encoded
+// values that are not reserved (like unicode characters).
+// Safe to call multiple times on the same path.
+function normalizePath(path) {
+  return replaceEncodedPercents(path, function(path) {
+    return percentEncodedValuesToUpper(decodeURI(path));
+  });
+}
+
+// Normalizes percent-encoded values to upper-case and decodes percent-encoded
+// values that are not reserved (like unicode characters).
+// Safe to call multiple times on the same route.
+function normalizeRoute(route) {
+  return replaceEncodedPercents(route, function(route) {
+    return percentEncodedValuesToUpper(decodeURI(route));
+  });
+}
+
+var Normalizer = {
+  normalizeRoute: normalizeRoute,
+  normalizePath: normalizePath
+};
+
+export default Normalizer;

--- a/lib/route-recognizer/normalizer.js
+++ b/lib/route-recognizer/normalizer.js
@@ -1,11 +1,8 @@
-
-// Matches all percent-encoded values like %25
+// Matches all percent-encoded values like %3a
 var percentEncodedValueRegex = /%[a-fA-F0-9]{2}/g;
 
 // The percent-encoding for the percent "%" character
 var percentEncodedPercent = "%25";
-
-var percentRegex = new RegExp(percentEncodedPercent, "g");
 
 function toUpper(str) { return str.toUpperCase(); }
 
@@ -15,55 +12,24 @@ function percentEncodedValuesToUpper(string) {
   return string.replace(percentEncodedValueRegex, toUpper);
 }
 
-function generateRandomString() {
-  return "_" + Math.floor(Math.random() * 1028).toString(16) + "_";
-}
-
-// Returns a sub string that does not occur in `string`
-function uniqueString(string) {
-  var random = generateRandomString();
-  while (string.indexOf(random) !== -1) {
-    random = generateRandomString();
-  }
-  return random;
-}
-
-// Replaces encoded percents ("%25") in string with a unique replacement value,
-// yields the string to the callback, and then replaces the replacement value
-// with encoded percents again before returning.
-// This is to work around the fact that `decodeURI` decodes "%25" -> "%" and is
-// therefore not safe to call multiple times on the same string.
-function replaceEncodedPercents(string, callback) {
-  var hasPercent = percentRegex.test(string);
-  var replacer;
-  if (hasPercent) {
-    replacer = uniqueString(string);
-    string = string.replace(percentRegex, replacer);
-  }
-  string = callback(string);
-  if (hasPercent) {
-    string = string.replace(new RegExp(replacer, "g"), percentEncodedPercent);
-  }
-
-  return string;
+function decodeURIWithoutPercents(string) {
+  return string.split(percentEncodedPercent).map(function(part) {
+    return decodeURI(part);
+  }).join(percentEncodedPercent);
 }
 
 // Normalizes percent-encoded values to upper-case and decodes percent-encoded
 // values that are not reserved (like unicode characters).
 // Safe to call multiple times on the same path.
 function normalizePath(path) {
-  return replaceEncodedPercents(path, function(path) {
-    return percentEncodedValuesToUpper(decodeURI(path));
-  });
+  return percentEncodedValuesToUpper(decodeURIWithoutPercents(path));
 }
 
 // Normalizes percent-encoded values to upper-case and decodes percent-encoded
 // values that are not reserved (like unicode characters).
 // Safe to call multiple times on the same route.
 function normalizeRoute(route) {
-  return replaceEncodedPercents(route, function(route) {
-    return percentEncodedValuesToUpper(decodeURI(route));
-  });
+  return percentEncodedValuesToUpper(decodeURIWithoutPercents(route));
 }
 
 var Normalizer = {

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -20,14 +20,65 @@ test("A simple route recognizes", function() {
   equal(router.recognize("/foo/baz"), null);
 });
 
-test("A unicode route recognizes", function() {
+test("A static route with non-ascii characters can be added in un-encoded form and recognized in encoded form", function() {
   var handler = {};
   var router = new RouteRecognizer();
-  router.add([{ path: "/uniçø∂∑/ʇɥƃᴉɹlɐ", handler: handler }]);
+  var unencoded = "/uniçø∂∑/ʇɥƃᴉɹlɐ";
+  var encoded = encodeURI(unencoded);
 
-  var encoded = encodeURI("/uniçø∂∑/ʇɥƃᴉɹlɐ");
+  router.add([{ path: unencoded, handler: handler }]);
   resultsMatch(router.recognize(encoded), [{ handler: handler, params: {}, isDynamic: false }]);
-  equal(router.recognize("/uniçø∂∑"), null);
+});
+
+test("A static route with non-ascii characters can be added in encoded form and recognized in encoded form", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  var unencoded = "/uniçø∂∑/ʇɥƃᴉɹlɐ";
+  var encoded = encodeURI(unencoded);
+
+  router.add([{ path: encoded, handler: handler }]);
+  resultsMatch(router.recognize(encoded), [{ handler: handler, params: {}, isDynamic: false }]);
+});
+
+// ":", "/" and "*" are reserved for the router micro-syntax, so they cannot appear in static segments
+test("A static route with URI-reserved characters other than ':', '/' and '*' can be added in un-encoded form and recognized in encoded form", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  var unencoded = "/foo]/$bar";
+  var encoded = encodeURI(unencoded); // "/foo%5D/%24bar"
+
+  router.add([{ path: unencoded, handler: handler }]);
+  resultsMatch(router.recognize(encoded), [{ handler: handler, params: {}, isDynamic: false }]);
+});
+
+test("A static route with URI-reserved characters other than ':', '/' and '*' can be added in encoded form and recognized in encoded form", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  var unencoded = "/foo]/$bar";
+  var encoded = encodeURI(unencoded); // "/foo%5D/%24bar"
+
+  router.add([{ path: encoded, handler: handler }]);
+  resultsMatch(router.recognize(encoded), [{ handler: handler, params: {}, isDynamic: false }]);
+});
+
+test("A static route with percent ('%') character can be added in un-encoded form and recognized in encoded form", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  var unencoded = "/foo%";
+  var encoded = encodeURI(unencoded); // "/foo%25".
+
+  router.add([{ path: unencoded, handler: handler }]);
+  resultsMatch(router.recognize(encoded), [{ handler: handler, params: {}, isDynamic: false }]);
+});
+
+test("A static route with percent ('%') character can be added in encoded form and recognized in encoded form", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  var unencoded = "/foo%";
+  var encoded = encodeURI(unencoded); // "/foo%25".
+
+  router.add([{ path: encoded, handler: handler }]);
+  resultsMatch(router.recognize(encoded), [{ handler: handler, params: {}, isDynamic: false }]);
 });
 
 test("A simple route with query params recognizes", function() {
@@ -129,7 +180,7 @@ test("A dynamic route recognizes", function() {
   equal(router.recognize("/zoo/baz"), null);
 });
 
-test("A simple dynamic route with an encoded segment recognizes", function() {
+test("A simple dynamic route recognizes a path with uri-encoded segment", function() {
   var handler = {};
   var router = new RouteRecognizer();
   router.add([{ path: "/foo/:bar", handler: handler }]);
@@ -139,7 +190,7 @@ test("A simple dynamic route with an encoded segment recognizes", function() {
   resultsMatch(router.recognize("/foo/" + encodedBar), [{ handler: handler, params: { bar: bar }, isDynamic: true }]);
 });
 
-test("A simple dynamic route with an encoded segment that includes an encoded % recognizes", function() {
+test("A simple dynamic route recognizes a path with uri-encoded segment when segment includes '%'", function() {
   var handler = {};
   var router = new RouteRecognizer();
   router.add([{ path: "/foo/:bar", handler: handler }]);

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -129,6 +129,26 @@ test("A dynamic route recognizes", function() {
   equal(router.recognize("/zoo/baz"), null);
 });
 
+test("A simple dynamic route with an encoded segment recognizes", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/foo/:bar", handler: handler }]);
+
+  var bar = "abc/def";
+  var encodedBar = encodeURIComponent(bar);
+  resultsMatch(router.recognize("/foo/" + encodedBar), [{ handler: handler, params: { bar: bar }, isDynamic: true }]);
+});
+
+test("A complex dynamic route with an encoded segment recognizes", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/foo/:bar/baz", handler: handler }]);
+
+  var bar = "abc/def";
+  var encodedBar = encodeURIComponent(bar);
+  resultsMatch(router.recognize("/foo/" + encodedBar + "/baz"), [{ handler: handler, params: { bar: bar }, isDynamic: true }]);
+});
+
 test("Multiple routes recognize", function() {
   var handler1 = { handler: 1 };
   var handler2 = { handler: 2 };

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -446,6 +446,14 @@ test("Generation works", function() {
   equal( router.generate("postIndex"), "/posts" );
 });
 
+test("Generation encodes dynamic segments", function() {
+  var postId = "abc/def";
+  var encodedPostId = encodeURIComponent(postId);
+  ok(postId !== encodedPostId, "precondition - encoded segment does not equal orginal segment");
+  equal( router.generate("post", { id: postId }), "/posts/" + encodedPostId );
+  equal( router.generate("edit_post", { id: postId }), "/posts/" + encodedPostId + "/edit" );
+});
+
 test("Parsing and generation results into the same input string", function() {
   var query = "filter%20data=date";
   equal(router.generateQueryString(router.parseQueryString(query)), '?' + query);

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -139,6 +139,18 @@ test("A simple dynamic route with an encoded segment recognizes", function() {
   resultsMatch(router.recognize("/foo/" + encodedBar), [{ handler: handler, params: { bar: bar }, isDynamic: true }]);
 });
 
+test("Setting RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS to false causes simple dynamic route with encoded path segment to not be decoded", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/foo/:bar", handler: handler }]);
+
+  var bar = "abc/def";
+  var encodedBar = encodeURIComponent(bar);
+  RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = false;
+  resultsMatch(router.recognize("/foo/" + encodedBar), [{ handler: handler, params: { bar: encodedBar }, isDynamic: true }]);
+  RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = true;
+});
+
 test("A complex dynamic route with an encoded segment recognizes", function() {
   var handler = {};
   var router = new RouteRecognizer();
@@ -147,6 +159,18 @@ test("A complex dynamic route with an encoded segment recognizes", function() {
   var bar = "abc/def";
   var encodedBar = encodeURIComponent(bar);
   resultsMatch(router.recognize("/foo/" + encodedBar + "/baz"), [{ handler: handler, params: { bar: bar }, isDynamic: true }]);
+});
+
+test("Setting RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS to false causes complex dynamic route with an encoded segment to not be decoded", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/foo/:bar/baz", handler: handler }]);
+
+  var bar = "abc/def";
+  var encodedBar = encodeURIComponent(bar);
+  RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = false;
+  resultsMatch(router.recognize("/foo/" + encodedBar + "/baz"), [{ handler: handler, params: { bar: encodedBar }, isDynamic: true }]);
+  RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = true;
 });
 
 test("Multiple routes recognize", function() {
@@ -453,6 +477,17 @@ test("Generation encodes dynamic segments", function() {
   equal( router.generate("post", { id: postId }), "/posts/" + encodedPostId );
   equal( router.generate("edit_post", { id: postId }), "/posts/" + encodedPostId + "/edit" );
 });
+
+test("Setting RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS to false causes generation to not encode dynamic segments", function() {
+  var postId = "abc/def";
+  var encodedPostId = encodeURIComponent(postId);
+  ok(postId !== encodedPostId, "precondition - encoded segment does not equal orginal segment");
+  RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = false;
+  equal( router.generate("post", { id: postId }), "/posts/" + postId );
+  equal( router.generate("edit_post", { id: postId }), "/posts/" + postId + "/edit" );
+  RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = true;
+});
+
 
 test("Parsing and generation results into the same input string", function() {
   var query = "filter%20data=date";

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -78,6 +78,16 @@ var encodedCharStaticExpectations = [{
   route: "/foo/b:ar",
   matches: ["/foo/b:ar"],
   nonmatches: ["/foo/b%3Aar", "/foo/b%3aar"]
+  /* FIXME should this work?
+}, {
+  // encoded non-uri-reserved char "*" in significant place
+  route: "/foo/%2Abar",
+  matches: ["/foo/*bar", "/foo/%2Abar", "/foo/%2baar"]
+  */
+}, {
+  // unencoded "*" in non-significant place
+  route: "/foo/b*ar",
+  matches: ["/foo/b*ar", "/foo/b%2Aar", "/foo/b%2aar"]
 }, {
   // unencoded " "
   route: "/foo /bar",

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -139,6 +139,16 @@ test("A simple dynamic route with an encoded segment recognizes", function() {
   resultsMatch(router.recognize("/foo/" + encodedBar), [{ handler: handler, params: { bar: bar }, isDynamic: true }]);
 });
 
+test("A simple dynamic route with an encoded segment that includes an encoded % recognizes", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/foo/:bar", handler: handler }]);
+
+  var bar = "abc%def";
+  var encodedBar = encodeURIComponent(bar);
+  resultsMatch(router.recognize("/foo/" + encodedBar), [{ handler: handler, params: { bar: bar }, isDynamic: true }]);
+});
+
 test("Setting RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS to false causes simple dynamic route with encoded path segment to not be decoded", function() {
   var handler = {};
   var router = new RouteRecognizer();

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -317,6 +317,53 @@ reservedCharDynamicExpectations.forEach(function(expectation) {
   });
 });
 
+var multiSegmentDynamicExpectations = [{
+  route: "/foo/:bar/baz",
+  path: "/foo/b ar/baz",
+  matches: { bar: "b ar" }
+}, {
+  route: "/foo/:bar/baz",
+  path: "/foo/b%20ar/baz",
+  matches: { bar: "b ar" }
+}, {
+  route: "/foo/:bar/baz",
+  path: "/foo/b%25ar/baz",
+  matches: { bar: "b%ar" }
+}, {
+  route: "/foo/:bar/baz",
+  path: "/foo/%3abar/baz",
+  matches: {bar: ":bar"}
+}, {
+  route: "/foo/:bar/baz",
+  path: "/foo/" + encodeURIComponent("http://example.com/some_url.html?abc=foo") + "/baz",
+  matches: { bar: "http://example.com/some_url.html?abc=foo" }
+}, {
+  route: "/:foo/bar/:baz",
+  path: "/föo/bar/bäz",
+  matches: {foo: "föo", baz: "bäz" }
+}, {
+  route: "/:foo/bar/:baz",
+  path: "/f%c3%b6o/bar/b%c3%a4z",
+  matches: {foo: "föo", baz: "bäz" }
+}, {
+  // route match names have unicode in them
+  route: "/:föo/bar/:bäz",
+  path: "/föo/bar/bäz",
+  matches: {föo: "föo", bäz: "bäz" }
+}];
+
+multiSegmentDynamicExpectations.forEach(function(expectation) {
+  var message = "A multi-segment dynamic route '" + expectation.route + "' recognizes path '" + expectation.path +
+    "' with matches: '" + JSON.stringify(expectation.matches) + "'";
+  test(message, function() {
+    var handler = {};
+    var router = new RouteRecognizer();
+    router.add([{ path: expectation.route, handler: handler }]);
+
+    resultsMatch(router.recognize(expectation.path), [{ handler: handler, params: expectation.matches, isDynamic: true }]);
+  });
+});
+
 var starExpectations = [{
   // encoded % is left encoded
   route: "/foo/*bar",
@@ -337,6 +384,16 @@ var starExpectations = [{
   route: "/foo/*bar",
   path: "/foo/bar/baz/blah/",
   match: "bar/baz/blah/"
+}, {
+  // unencoded url
+  route: "/foo/*bar",
+  path: "/foo/http://example.com/abc_def.html",
+  match: "http://example.com/abc_def.html"
+}, {
+  // encoded url
+  route: "/foo/*bar",
+  path: "/foo/" + encodeURIComponent("http://example.com/abc_%def.html"),
+  match: encodeURIComponent("http://example.com/abc_%def.html")
 }];
 
 starExpectations.forEach(function(expectation) {


### PR DESCRIPTION
This allows handlers like "/foo/:bar" to match a path with a url encoded
segment such as "/foo/abc%2Fdef" -> `{ params: { bar: "abc/def" } }` (instead of incorrectly recognizing the value of ":bar" as "abc%2Fdef").

It also changes the route-recognizer to encode segments in the same way when generating a url.
For example, generating a `postShow` route with the path "/posts/:id" and params `{id: 'abc/def'}` will return the url "/posts/abc%2Fdef" instead of the incorrect "/posts/abc/def".

This code will fix this related ember issue: https://github.com/emberjs/ember.js/issues/11497

Decoding and encoding URI segments is the way the rails router also works. I put together a [demo Rails app](https://github.com/bantic/decode_uri_rails_example) to demonstrate.

Adds a flag `RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS` that is initially true and can be set to false by consumers to opt-out of this bugfix.