### PR TITLE
handle malformed URI error

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -319,7 +319,11 @@ function addSegment(currentState, segment) {
 function decodeQueryParamPart(part) {
   // http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1
   part = part.replace(/\+/gm, '%20');
-  return decodeURIComponent(part);
+  var result;
+  try {
+    result = decodeURIComponent(part);
+  } catch(error) {result = '';}
+  return result;
 }
 
 // The main interface

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -141,6 +141,15 @@ test("Multiple routes recognize", function() {
   resultsMatch(router.recognize("/bar/1"), [{ handler: handler2, params: { baz: "1" }, isDynamic: true }]);
 });
 
+test("ignore the URI malformed error", function() {
+  var handler1 = { handler: 1 };
+  var router = new RouteRecognizer();
+
+  router.add([{ path: "/foo", handler: handler1 }]);
+
+  deepEqual(router.recognize("/foo?a=1%").queryParams, {a: ""});
+});
+
 test("Multiple routes with overlapping query params recognize", function() {
   var handler1 = { handler: 1 };
   var handler2 = { handler: 2 };

--- a/tests/router-tests.js
+++ b/tests/router-tests.js
@@ -157,7 +157,7 @@ test("supports star routes", function() {
 
 test("star route does not swallow trailing `/`", function() {
   var r;
-  
+
   router.map(function(match) {
     match("/").to("posts");
     match("/*everything").to("glob");
@@ -173,7 +173,7 @@ test("support star route before other segment", function() {
   });
 
   ["folder1/folder2/folder3//the-extra-stuff/", "folder1/folder2/folder3//the-extra-stuff"].forEach(function(r) {
-    matchesRoute("/" + r, [{ handler: "glob", params: {everything: "folder1/folder2/folder3/", extra: "the-extra-stuff"}, isDynamic: true}]);  
+    matchesRoute("/" + r, [{ handler: "glob", params: {everything: "folder1/folder2/folder3/", extra: "the-extra-stuff"}, isDynamic: true}]);
   });
 });
 
@@ -258,4 +258,3 @@ test("supports add-route callback", function() {
   matchesRoute("/posts/new", [{ handler: "newPost", params: {}, isDynamic: false }]);
   ok(called, "The add-route callback was called.");
 });
-


### PR DESCRIPTION
when a queryParam is malformed `?foo=bar%` an error is thrown `URIError: URI malformed` this commit handles the error and ignores the value of the queryParam