### PR TITLE
Use decodeURIComponent in recognize method

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -495,7 +495,7 @@ RouteRecognizer.prototype = {
       queryParams = this.parseQueryString(queryString);
     }
 
-    path = decodeURI(path);
+    path = decodeURIComponent(path);
 
     // DEBUG GROUP path
 

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -30,6 +30,16 @@ test("A unicode route recognizes", function() {
   equal(router.recognize("/uniçø∂∑"), null);
 });
 
+test("A route with reserved characters recognizes", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/some/reserved?#@:$&+,/=;characters", handler: handler }]);
+
+  var encoded = "/some/" + encodeURIComponent("reserved?#@:$&+,/=;characters");
+  resultsMatch(router.recognize(encoded), [{ handler: handler, params: {}, isDynamic: false }]);
+  equal(router.recognize("/some/eserved?#@:$&+,/=;"), null);
+});
+
 test("A simple route with query params recognizes", function() {
   var handler = {};
   var router = new RouteRecognizer();


### PR DESCRIPTION
This change would allow matching of URI with encoded characters for ":", "/", ";", and "?". (Since decodeURI does not decode these characters, recognize would not match this.).

Also, this keeps the usage of encodeURIComponent/decodeURIComponent consistent. (This is the only instance of decodeURI used)