### PR TITLE
Decode route before parsing.

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -88,6 +88,8 @@ EpsilonSegment.prototype = {
 function parse(route, names, specificity) {
   // normalize route as not starting with a "/". Recognition will
   // also normalize.
+  route = decodeURIComponent(route);
+
   if (route.charAt(0) === "/") { route = route.substr(1); }
 
   var segments = route.split("/"), results = [];

--- a/tests/router-tests.js
+++ b/tests/router-tests.js
@@ -177,6 +177,14 @@ test("support star route before other segment", function() {
   });
 });
 
+test("supports URL encoded route's calls to match", function() {
+  router.map(function(match) {
+    match("/all%20posts").to("indexPost");
+  });
+
+  matchesRoute("/all%20posts", [{ handler: "indexPost", params: {}, isDynamic: false }]);
+});
+
 test("support nested star route", function() {
   router.map(function(match) {
     match("/*everything").to("glob", function(match){


### PR DESCRIPTION
Since the route recognizer ~~`match`~~`recognize` supports decoding before the match,
it makes sense for the parser to also decode URI components before
it starts parsing the route.

This should solve https://github.com/pretenderjs/pretender/issues/124.

While the test I added failed both in chrome & phantomjs, this might
also be relevant to https://github.com/pretenderjs/pretender/pull/111.