### PR TITLE
Relax array query params needing to have brackets []

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -461,23 +461,29 @@ RouteRecognizer.prototype = {
       var pair      = pairs[i].split('='),
           key       = decodeQueryParamPart(pair[0]),
           keyLength = key.length,
-          isArray = false,
-          value;
+          isArrayIndicatedByBrackets = false,
+          value,
+          isAlreadySeen;
+
       if (pair.length === 1) {
         value = 'true';
       } else {
-        //Handle arrays
-        if (keyLength > 2 && key.slice(keyLength -2) === '[]') {
-          isArray = true;
+        isArrayIndicatedByBrackets = keyLength > 2 && key.slice(keyLength -2) === '[]';
+        if (isArrayIndicatedByBrackets) {
           key = key.slice(0, keyLength - 2);
-          if(!queryParams[key]) {
-            queryParams[key] = [];
-          }
         }
         value = pair[1] ? decodeQueryParamPart(pair[1]) : '';
       }
-      if (isArray) {
+
+      isAlreadySeen = queryParams[key] !== undefined;
+      if (isAlreadySeen) {
+        if (!isArray(queryParams[key])) {
+          queryParams[key] = [queryParams[key]];
+        }
+
         queryParams[key].push(value);
+      } else if (isArrayIndicatedByBrackets) {
+        queryParams[key] = [value];
       } else {
         queryParams[key] = value;
       }

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -180,9 +180,29 @@ test("Deserialize query param array", function() {
   var router = new RouteRecognizer();
   router.add([{ path: "/foo/bar", handler: handler }]);
 
-  var p = router.recognize("/foo/bar?foo[]=1&foo[]=2").queryParams;
+  var p = router.recognize("/foo/bar?foo[]=1&foo[]=2&bar=3&bar=4&baz=5").queryParams;
   ok(Array.isArray(p.foo), "foo is an Array");
+  ok(Array.isArray(p.bar), "bar is an Array");
+  ok(!Array.isArray(p.baz), "baz is not an Array");
+  deepEqual(p, {foo: ["1","2"], bar: ["3","4"], baz: "5"});
+});
+
+test("Deserialize query param array, mixed with/without brackets", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/foo/bar", handler: handler }]);
+
+  var p = router.recognize("/foo/bar?foo[]=1&foo=2").queryParams;
   deepEqual(p, {foo: ["1","2"]});
+});
+
+test("Deserialize query param array of size 1", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/foo/bar", handler: handler }]);
+
+  var p = router.recognize("/foo/bar?foo[]=1").queryParams;
+  deepEqual(p, {foo: ["1"]});
 });
 
 test("Array query params do not conflict with controller namespaced query params", function() {


### PR DESCRIPTION
[This line](https://github.com/tildeio/route-recognizer/blob/0.1.9/lib/route-recognizer.js#L468) in route-recognizer.js requires array query params to have brackets, e.g. `/some-route?foo[]=1&foo[]=2`. I use an API that recognizes arrays of params without the brackets, e.g. `/some-route?foo=1&foo=2`. I can't find anything in the HTTP spec requiring brackets or otherwise indicating this API is out of line. So, this PR relaxes things.

* A param's value becomes an array if any of the following:
    * The param name ends with [] at least once
    * The param name occurs more than once
* The [] are still always stripped in the `queryParams` match object

## Compatibility

1. This maintains backwards compatibility for those using `foo[]=1&foo[]=2` notation.
2. This is a **breaking change** for anybody who was **expecting all but the last value to be overwritten**, e.g. for `foo=1&foo=2` to parse as `{ foo: 2 }`. It now parses as `{ foo: [1, 2] }`. Not sure why you'd send multiple params only to discard all but the last. Nevertheless, it is a breaking change.
3. This helps nothing if you are **mixing** `foo=1&foo[]=2` and **want** to interpret them differently. As with 2., the final `foo[]=2` will no longer overwrite the first; you will get `{ foo: [1, 2] }`. But the values are both under the same key. There's no way to distinguish the keys as e.g. `{ "foo": 1, "foo[]": 2 }`.

## Open Issues

1. I've added tests for _deserializing_ query params. Should I be touching route _generation_? In route generation, query params still all get `[]`s at the end.