### PR TITLE
[PERF] Cache results of State.get

### DIFF
--- a/dist/route-recognizer.js
+++ b/dist/route-recognizer.js
@@ -259,10 +259,15 @@
     function $$route$recognizer$$State(charSpec) {
       this.charSpec = charSpec;
       this.nextStates = [];
+      this.charSpecs = {};
     }
 
     $$route$recognizer$$State.prototype = {
       get: function(charSpec) {
+        if (this.charSpecs[charSpec.validChars]) {
+          return this.charSpecs[charSpec.validChars];
+        }
+
         var nextStates = this.nextStates;
 
         for (var i=0; i<nextStates.length; i++) {
@@ -271,7 +276,10 @@
           var isEqual = child.charSpec.validChars === charSpec.validChars;
           isEqual = isEqual && child.charSpec.invalidChars === charSpec.invalidChars;
 
-          if (isEqual) { return child; }
+          if (isEqual) {
+            this.charSpecs[charSpec.validChars] = child;
+            return child;
+          }
         }
       },
 

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -159,10 +159,15 @@ function parse(route, names, specificity) {
 function State(charSpec) {
   this.charSpec = charSpec;
   this.nextStates = [];
+  this.charSpecs = {};
 }
 
 State.prototype = {
   get: function(charSpec) {
+    if (this.charSpecs[charSpec.validChars]) {
+      return this.charSpecs[charSpec.validChars];
+    }
+
     var nextStates = this.nextStates;
 
     for (var i=0; i<nextStates.length; i++) {
@@ -171,7 +176,10 @@ State.prototype = {
       var isEqual = child.charSpec.validChars === charSpec.validChars;
       isEqual = isEqual && child.charSpec.invalidChars === charSpec.invalidChars;
 
-      if (isEqual) { return child; }
+      if (isEqual) {
+        this.charSpecs[charSpec.validChars] = child;
+        return child;
+      }
     }
   },
 


### PR DESCRIPTION
Speed up of about ~30 op/s consistently overall. 5000 op/s improvement around `recognize`. Tried using an object that was placed into dictionary mode for the cache as the shape changes overtime but seemed slower.
```
  Add ................... 505.78 op/s
  End-to-end ............ 270.97 op/s
  Generate ........ 4,874,011.82 op/s
  Handlers For ... 37,588,869.18 op/s
  Recognize ......... 360,278.12 op/s
```