### PR TITLE
Remove commented DEBUG statements

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -216,11 +216,9 @@ State.prototype = {
 
   // Find a list of child states matching the next character
   match: function(ch) {
-    // DEBUG "Processing `" + ch + "`:"
     var nextStates = this.nextStates,
         child, charSpec, chars;
 
-    // DEBUG "  " + debugState(this)
     var returned = [];
 
     for (var i=0; i<nextStates.length; i++) {
@@ -237,36 +235,7 @@ State.prototype = {
 
     return returned;
   }
-
-  /** IF DEBUG
-  , debug: function() {
-    var charSpec = this.charSpec,
-        debug = "[",
-        chars = charSpec.validChars || charSpec.invalidChars;
-
-    if (charSpec.invalidChars) { debug += "^"; }
-    debug += chars;
-    debug += "]";
-
-    if (charSpec.repeat) { debug += "+"; }
-
-    return debug;
-  }
-  END IF **/
 };
-
-/** IF DEBUG
-function debug(log) {
-  console.log(log);
-}
-
-function debugState(state) {
-  return state.nextStates.map(function(n) {
-    if (n.nextStates.length === 0) { return "( " + n.debug() + " [accepting] )"; }
-    return "( " + n.debug() + " <then> " + n.nextStates.map(function(s) { return s.debug() }).join(" or ") + " )";
-  }).join(", ")
-}
-END IF **/
 
 // Sort the routes by specificity
 function sortSolutions(states) {
@@ -511,8 +480,6 @@ RouteRecognizer.prototype = {
 
     path = decodeURI(path);
 
-    // DEBUG GROUP path
-
     if (path.charAt(0) !== "/") { path = "/" + path; }
 
     pathLen = path.length;
@@ -525,8 +492,6 @@ RouteRecognizer.prototype = {
       states = recognizeChar(states, path.charAt(i));
       if (!states.length) { break; }
     }
-
-    // END DEBUG GROUP
 
     var solutions = [];
     for (i=0; i<states.length; i++) {


### PR DESCRIPTION
route-recognizer originally used a Rakefile to build that had a [replace_debug method](https://github.com/tildeio/route-recognizer/blob/fa15bd6ad0f9ff2f07e2df5b94ca6a07fe22e12a/Rakefile#L3-L13) that would conditionally turn the `// DEBUG` lines into console logs, but when the build system [changed to broccoli](https://github.com/tildeio/route-recognizer/commit/efc828d426f2ae9b21c0c27ebf61f4a150a6a67f#diff-52c976fc38ed2b4e3b1192f8a8e24cffL6) the debug build was removed. These `// DEBUG` comments in the code are thus no longer used.