### PR TITLE
normalize route and path, encoded and decode dynamic path segments

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -36,7 +36,7 @@ function buildTestSuite (libTree) {
   var jsHintLib = jsHint(libTree);
 
   var testTree = new Funnel( 'tests', {
-    files: ['recognizer-tests.js', 'router-tests.js'],
+    files: ['recognizer-tests.js', 'router-tests.js', 'normalizer-tests.js'],
     destDir: destination
   });
 

--- a/bench/benches/normalize.js
+++ b/bench/benches/normalize.js
@@ -1,0 +1,28 @@
+var RouteRecognizer = require('../../dist/route-recognizer');
+var Normalizer = RouteRecognizer.Normalizer;
+
+var router = new RouteRecognizer();
+
+var paths = {
+  complex: "/foo/" + encodeURIComponent("http://example.com/index.html?foo=bar&baz=faz#hashtag"),
+  simple: "/post/123",
+  medium: "/abc%3Adef"
+
+};
+
+module.exports = [{
+  name: 'Normalize Complex',
+  fn: function() {
+    Normalizer.normalizePath(paths.complex);
+  }
+}, {
+  name: 'Normalize Simple',
+  fn: function() {
+    Normalizer.normalizePath(paths.simple);
+  }
+}, {
+  name: 'Normalize Medium',
+  fn: function() {
+    Normalizer.normalizePath(paths.medium);
+  }
+}];

--- a/bench/index.js
+++ b/bench/index.js
@@ -2,6 +2,14 @@ var glob = require('glob');
 var path = require('path');
 var bench = require('do-you-even-bench');
 
-bench(glob.sync( './bench/benches/*.js' ).map( function( file ) {
-  return require( path.resolve( file ) );
-}));
+var suites = [];
+glob.sync( './bench/benches/*.js' ).forEach(function(file) {
+  var exported = require( path.resolve( file ) );
+  if (Array.isArray(exported)) {
+    suites = suites.concat(exported);
+  } else {
+    suites.push(exported);
+  }
+});
+
+bench(suites);

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -1,4 +1,8 @@
 import map from './route-recognizer/dsl';
+import Normalizer from './route-recognizer/normalizer';
+
+var normalizeRoute = Normalizer.normalizeRoute;
+var normalizePath = Normalizer.normalizePath;
 
 var specials = [
   '/', '.', '*', '+', '?', '|',
@@ -61,7 +65,11 @@ DynamicSegment.prototype = {
   },
 
   generate: function(params) {
-    return params[this.name];
+    if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS) {
+      return encodeURIComponent(params[this.name]);
+    } else {
+      return params[this.name];
+    }
   }
 };
 
@@ -94,6 +102,7 @@ function parse(route, names, specificity) {
   // also normalize.
   if (route.charAt(0) === "/") { route = route.substr(1); }
 
+  route = normalizeRoute(route);
   var segments = route.split("/");
   var results = new Array(segments.length);
 
@@ -167,6 +176,7 @@ function State(charSpec) {
   this.regex = undefined;
   this.handlers = undefined;
   this.specificity = undefined;
+  this.hasStar = false;
 }
 
 State.prototype = {
@@ -284,7 +294,16 @@ function findHandler(state, path, queryParams) {
     var handler = handlers[i], names = handler.names, params = {};
 
     for (var j=0; j<names.length; j++) {
-      params[names[j]] = captures[currentCapture++];
+      if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS) {
+        // Never decode the star segment glob capture
+        if (state.hasStar && currentCapture === (captures.length - 1)) {
+          params[names[j]] = captures[currentCapture++];
+        } else {
+          params[names[j]] = decodeURIComponent(captures[currentCapture++]);
+        }
+      } else {
+        params[names[j]] = captures[currentCapture++];
+      }
     }
 
     result[i] = { handler: handler.handler, params: params, isDynamic: !!names.length };
@@ -340,6 +359,11 @@ RouteRecognizer.prototype = {
         // Add a representation of the segment to the NFA and regex
         currentState = segment.eachChar(currentState);
         regex += segment.regex();
+
+        // Mark the state as having a starSegment if the last segment is a star segment
+        if (segment instanceof StarSegment && j === segments.length - 1) {
+          currentState.hasStar = true;
+        }
       }
       var handler = { handler: route.handler, names: names };
       handlers[i] = handler;
@@ -478,7 +502,11 @@ RouteRecognizer.prototype = {
       queryParams = this.parseQueryString(queryString);
     }
 
-    path = decodeURI(path);
+    if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS) {
+      path = normalizePath(path);
+    } else {
+      path = decodeURI(path);
+    }
 
     if (path.charAt(0) !== "/") { path = "/" + path; }
 
@@ -516,5 +544,9 @@ RouteRecognizer.prototype = {
 RouteRecognizer.prototype.map = map;
 
 RouteRecognizer.VERSION = 'VERSION_STRING_PLACEHOLDER';
+
+// Set to false to opt-out of encoding and decoding path segments.
+// See https://github.com/tildeio/route-recognizer/pull/55
+RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = true;
 
 export default RouteRecognizer;

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -99,6 +99,10 @@ EpsilonSegment.prototype = {
   generate: function() { return ""; }
 };
 
+// The `names` will be populated with {name, decode} objects for each
+// dynamic/star segment, where `name` is the parameter name for use during
+// recognition, and `decode` is whether the parameter value should be decoded
+// (true for dynamic segments, false for star segments).
 function parse(route, names, specificity) {
   // normalize route as not starting with a "/". Recognition will
   // also normalize.
@@ -133,12 +137,12 @@ function parse(route, names, specificity) {
 
     if (match = segment.match(/^:([^\/]+)$/)) {
       results[i] = new DynamicSegment(match[1]);
-      names.push(match[1]);
+      names.push({name: match[1], decode: true});
       specificity.val += '3';
     } else if (match = segment.match(/^\*([^\/]+)$/)) {
       results[i] = new StarSegment(match[1]);
+      names.push({name: match[1], decode: false});
       specificity.val += '1';
-      names.push(match[1]);
     } else if(segment === "") {
       results[i] = new EpsilonSegment();
       specificity.val += '2';
@@ -177,7 +181,6 @@ function State(charSpec) {
   this.regex = undefined;
   this.handlers = undefined;
   this.specificity = undefined;
-  this.hasStar = false;
 }
 
 State.prototype = {
@@ -284,7 +287,7 @@ RecognizeResults.prototype = oCreate({
   queryParams: null
 });
 
-function findHandler(state, path, queryParams, originalPath) {
+function findHandler(state, originalPath, queryParams) {
   var handlers = state.handlers, regex = state.regex;
   var captures = originalPath.match(regex), currentCapture = 1;
   var result = new RecognizeResults(queryParams);
@@ -293,17 +296,21 @@ function findHandler(state, path, queryParams, originalPath) {
 
   for (var i=0; i<handlers.length; i++) {
     var handler = handlers[i], names = handler.names, params = {};
+    var name, shouldDecode, capture;
 
     for (var j=0; j<names.length; j++) {
+      name = names[j].name;
+      shouldDecode = names[j].decode;
+      capture = captures[currentCapture++];
+
       if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS) {
-        // Never decode the star segment glob capture
-        if (state.hasStar && currentCapture === (captures.length - 1)) {
-          params[names[j]] = captures[currentCapture++];
+        if (shouldDecode) {
+          params[name] = decodeURIComponent(capture);
         } else {
-          params[names[j]] = decodeURIComponent(captures[currentCapture++]);
+          params[name] = capture;
         }
       } else {
-        params[names[j]] = captures[currentCapture++];
+        params[name] = capture;
       }
     }
 
@@ -360,11 +367,6 @@ RouteRecognizer.prototype = {
         // Add a representation of the segment to the NFA and regex
         currentState = segment.eachChar(currentState);
         regex += segment.regex();
-
-        // Mark the state as having a starSegment if the last segment is a star segment
-        if (segment instanceof StarSegment && j === segments.length - 1) {
-          currentState.hasStar = true;
-        }
       }
       var handler = { handler: route.handler, names: names };
       handlers[i] = handler;
@@ -544,10 +546,9 @@ RouteRecognizer.prototype = {
       // if a trailing slash was dropped and a star segment is the last segment
       // specified, put the trailing slash back
       if (isSlashDropped && state.regex.source.slice(-5) === "(.+)$") {
-        path = path + "/";
-        originalPath = originalPath + "/";
-      }
-      return findHandler(state, path, queryParams, originalPath);
+         originalPath = originalPath + "/";
+       }
+      return findHandler(state, originalPath, queryParams);
     }
   }
 };

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -1,10 +1,8 @@
 import map from './route-recognizer/dsl';
 import Normalizer from './route-recognizer/normalizer';
 
-var normalizeRoute = Normalizer.normalizeRoute;
 var normalizePath = Normalizer.normalizePath;
 var normalizeRouteSegment = Normalizer.normalizeRouteSegment;
-var normalizePathSegment = Normalizer.normalizePathSegment;
 
 var specials = [
   '/', '.', '*', '+', '?', '|',

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -284,9 +284,9 @@ RecognizeResults.prototype = oCreate({
   queryParams: null
 });
 
-function findHandler(state, path, queryParams) {
+function findHandler(state, path, queryParams, originalPath) {
   var handlers = state.handlers, regex = state.regex;
-  var captures = path.match(regex), currentCapture = 1;
+  var captures = originalPath.match(regex), currentCapture = 1;
   var result = new RecognizeResults(queryParams);
 
   result.length = handlers.length;
@@ -509,17 +509,20 @@ RouteRecognizer.prototype = {
       queryParams = this.parseQueryString(queryString);
     }
 
+    if (path.charAt(0) !== "/") { path = "/" + path; }
+    var originalPath = path;
+
     if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS) {
       path = normalizePath(path);
     } else {
       path = decodeURI(path);
+      originalPath = decodeURI(originalPath);
     }
-
-    if (path.charAt(0) !== "/") { path = "/" + path; }
 
     pathLen = path.length;
     if (pathLen > 1 && path.charAt(pathLen - 1) === "/") {
       path = path.substr(0, pathLen - 1);
+      originalPath = originalPath.substr(0, pathLen - 1);
       isSlashDropped = true;
     }
 
@@ -542,8 +545,9 @@ RouteRecognizer.prototype = {
       // specified, put the trailing slash back
       if (isSlashDropped && state.regex.source.slice(-5) === "(.+)$") {
         path = path + "/";
+        originalPath = originalPath + "/";
       }
-      return findHandler(state, path, queryParams);
+      return findHandler(state, path, queryParams, originalPath);
     }
   }
 };

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -2,7 +2,7 @@ import map from './route-recognizer/dsl';
 import Normalizer from './route-recognizer/normalizer';
 
 var normalizePath = Normalizer.normalizePath;
-var normalizeRouteSegment = Normalizer.normalizeRouteSegment;
+var normalizeSegment = Normalizer.normalizeSegment;
 
 var specials = [
   '/', '.', '*', '+', '?', '|',
@@ -32,7 +32,7 @@ function isArray(test) {
 // * `invalidChars`: a String with a list of all invalid characters
 // * `repeat`: true if the character specification can repeat
 
-function StaticSegment(string) { this.string = normalizeRouteSegment(string); }
+function StaticSegment(string) { this.string = normalizeSegment(string); }
 StaticSegment.prototype = {
   eachChar: function(currentState) {
     var string = this.string, ch;
@@ -54,7 +54,7 @@ StaticSegment.prototype = {
   }
 };
 
-function DynamicSegment(name) { this.name = normalizeRouteSegment(name); }
+function DynamicSegment(name) { this.name = normalizeSegment(name); }
 DynamicSegment.prototype = {
   eachChar: function(currentState) {
     return currentState.put({ invalidChars: "/", repeat: true, validChars: undefined });
@@ -558,5 +558,7 @@ RouteRecognizer.VERSION = 'VERSION_STRING_PLACEHOLDER';
 // Set to false to opt-out of encoding and decoding path segments.
 // See https://github.com/tildeio/route-recognizer/pull/55
 RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = true;
+
+RouteRecognizer.Normalizer = Normalizer;
 
 export default RouteRecognizer;

--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -3,6 +3,8 @@ import Normalizer from './route-recognizer/normalizer';
 
 var normalizeRoute = Normalizer.normalizeRoute;
 var normalizePath = Normalizer.normalizePath;
+var normalizeRouteSegment = Normalizer.normalizeRouteSegment;
+var normalizePathSegment = Normalizer.normalizePathSegment;
 
 var specials = [
   '/', '.', '*', '+', '?', '|',
@@ -32,7 +34,7 @@ function isArray(test) {
 // * `invalidChars`: a String with a list of all invalid characters
 // * `repeat`: true if the character specification can repeat
 
-function StaticSegment(string) { this.string = string; }
+function StaticSegment(string) { this.string = normalizeRouteSegment(string); }
 StaticSegment.prototype = {
   eachChar: function(currentState) {
     var string = this.string, ch;
@@ -54,7 +56,7 @@ StaticSegment.prototype = {
   }
 };
 
-function DynamicSegment(name) { this.name = name; }
+function DynamicSegment(name) { this.name = normalizeRouteSegment(name); }
 DynamicSegment.prototype = {
   eachChar: function(currentState) {
     return currentState.put({ invalidChars: "/", repeat: true, validChars: undefined });
@@ -102,7 +104,6 @@ function parse(route, names, specificity) {
   // also normalize.
   if (route.charAt(0) === "/") { route = route.substr(1); }
 
-  route = normalizeRoute(route);
   var segments = route.split("/");
   var results = new Array(segments.length);
 
@@ -493,7 +494,13 @@ RouteRecognizer.prototype = {
   recognize: function(path) {
     var states = [ this.rootState ],
         pathLen, i, l, queryStart, queryParams = {},
+        hashStart,
         isSlashDropped = false;
+
+    hashStart = path.indexOf('#');
+    if (hashStart !== -1) {
+      path = path.substr(0, hashStart);
+    }
 
     queryStart = path.indexOf('?');
     if (queryStart !== -1) {

--- a/lib/route-recognizer/normalizer.js
+++ b/lib/route-recognizer/normalizer.js
@@ -1,21 +1,11 @@
-// Matches all percent-encoded values like %3a
-var percentEncodedValueRegex = /%[a-fA-F0-9]{2}/g;
-
-// The percent-encoding for the percent "%" character
-var percentEncodedPercent = "%25";
+// Match percent-encoded values (e.g. %3a, %3A, %25)
+var PERCENT_ENCODED_VALUES = /%[a-fA-F0-9]{2}/g;
 
 function toUpper(str) { return str.toUpperCase(); }
 
-// Turns all percent-encoded values to upper case
-// "%3a" -> "%3A"
+// Turn percent-encoded values to upper case ("%3a" -> "%3A")
 function percentEncodedValuesToUpper(string) {
-  return string.replace(percentEncodedValueRegex, toUpper);
-}
-
-function decodeURIWithoutPercents(string) {
-  return string.split(percentEncodedPercent)
-               .map(decodeURI)
-               .join(percentEncodedPercent);
+  return string.replace(PERCENT_ENCODED_VALUES, toUpper);
 }
 
 // Normalizes percent-encoded values to upper-case and decodes percent-encoded
@@ -27,13 +17,6 @@ function normalizePath(path) {
              .join('/');
 }
 
-// Normalizes percent-encoded values to upper-case and decodes percent-encoded
-// values that are not reserved (like unicode characters).
-// Safe to call multiple times on the same route.
-function normalizeRoute(route) {
-  return decodeURIWithoutPercents(percentEncodedValuesToUpper(route));
-}
-
 function percentEncode(char) {
   return '%' + charToHex(char);
 }
@@ -42,41 +25,50 @@ function charToHex(char) {
   return char.charCodeAt(0).toString(16).toUpperCase();
 }
 
+// Decodes percent-encoded values in the string except those
+// characters in `reservedSet`
 function decodeURIComponentExcept(string, reservedSet) {
   string = percentEncodedValuesToUpper(string);
   var replacements = {};
+
   for (var i=0; i < reservedSet.length; i++) {
     var char = reservedSet[i];
     var pChar = percentEncode(char);
     if (string.indexOf(pChar) !== -1) {
       var replacement = "__" + charToHex(char) + "__";
       replacements[pChar] = replacement;
-      string = string.replace(new RegExp(pChar, 'g'), replacement);
+
+      var pCharRegex = new RegExp(pChar, 'g');
+      string = string.replace(pCharRegex, replacement);
     }
   }
   string = decodeURIComponent(string);
 
   Object.keys(replacements).forEach(function(pChar) {
     var replacement = replacements[pChar];
-    string = string.replace(new RegExp(replacement, 'g'), pChar);
+    var replacementRegex = new RegExp(replacement, 'g');
+
+    string = string.replace(replacementRegex, pChar);
   });
 
   return string;
 }
 
+// Leave these characters in encoded state in segments
+var reservedRouteSegmentChars = ['%', '/'];
+var reservedPathSegmentChars = ['%', '/'];
+
 function normalizeRouteSegment(segment) {
-  return decodeURIComponentExcept(segment, ['%', '/']);
+  return decodeURIComponentExcept(segment, reservedRouteSegmentChars);
 }
 
 function normalizePathSegment(segment) {
-  return decodeURIComponentExcept(segment, ['%', '/']);
+  return decodeURIComponentExcept(segment, reservedPathSegmentChars);
 }
 
 var Normalizer = {
-  normalizeRoute: normalizeRoute,
   normalizeRouteSegment: normalizeRouteSegment,
-  normalizePath: normalizePath,
-  normalizePathSegment: normalizePathSegment
+  normalizePath: normalizePath
 };
 
 export default Normalizer;

--- a/lib/route-recognizer/normalizer.js
+++ b/lib/route-recognizer/normalizer.js
@@ -13,7 +13,7 @@ function percentEncodedValuesToUpper(string) {
 // Safe to call multiple times on the same path.
 function normalizePath(path) {
   return path.split('/')
-             .map(normalizePathSegment)
+             .map(normalizeSegment)
              .join('/');
 }
 
@@ -26,48 +26,56 @@ function charToHex(char) {
 }
 
 // Decodes percent-encoded values in the string except those
-// characters in `reservedSet`
-function decodeURIComponentExcept(string, reservedSet) {
+// characters in `reservedHex`, where `reservedHex` is an array of 2-character
+// percent-encodings
+function decodeURIComponentExcept(string, reservedHex) {
+  if (string.indexOf('%') === -1) {
+    // If there is no percent char, there is no decoding that needs to
+    // be done and we exit early
+    return string;
+  }
   string = percentEncodedValuesToUpper(string);
-  var replacements = {};
 
-  for (var i=0; i < reservedSet.length; i++) {
-    var char = reservedSet[i];
-    var pChar = percentEncode(char);
-    if (string.indexOf(pChar) !== -1) {
-      var replacement = "__" + charToHex(char) + "__";
-      replacements[pChar] = replacement;
+  var result = '';
+  var buffer = '';
+  var idx = 0;
+  while (idx < string.length) {
+    var pIdx = string.indexOf('%', idx);
 
-      var pCharRegex = new RegExp(pChar, 'g');
-      string = string.replace(pCharRegex, replacement);
+    if (pIdx === -1) { // no percent char
+      buffer += string.slice(idx);
+      break;
+    } else { // found percent char
+      buffer += string.slice(idx, pIdx);
+      idx = pIdx + 3;
+
+      var hex = string.slice(pIdx + 1, pIdx + 3);
+      var encoded = '%' + hex;
+
+      if (reservedHex.indexOf(hex) === -1) {
+        // encoded is not in reserved set, add to buffer
+        buffer += encoded;
+      } else {
+        result += decodeURIComponent(buffer);
+        buffer = '';
+        result += encoded;
+      }
     }
   }
-  string = decodeURIComponent(string);
-
-  Object.keys(replacements).forEach(function(pChar) {
-    var replacement = replacements[pChar];
-    var replacementRegex = new RegExp(replacement, 'g');
-
-    string = string.replace(replacementRegex, pChar);
-  });
-
-  return string;
+  result += decodeURIComponent(buffer);
+  return result;
 }
 
 // Leave these characters in encoded state in segments
-var reservedRouteSegmentChars = ['%', '/'];
-var reservedPathSegmentChars = ['%', '/'];
+var reservedSegmentChars = ['%', '/'];
+var reservedHex = reservedSegmentChars.map(charToHex);
 
-function normalizeRouteSegment(segment) {
-  return decodeURIComponentExcept(segment, reservedRouteSegmentChars);
-}
-
-function normalizePathSegment(segment) {
-  return decodeURIComponentExcept(segment, reservedPathSegmentChars);
+function normalizeSegment(segment) {
+  return decodeURIComponentExcept(segment, reservedHex);
 }
 
 var Normalizer = {
-  normalizeRouteSegment: normalizeRouteSegment,
+  normalizeSegment: normalizeSegment,
   normalizePath: normalizePath
 };
 

--- a/lib/route-recognizer/normalizer.js
+++ b/lib/route-recognizer/normalizer.js
@@ -1,0 +1,40 @@
+// Matches all percent-encoded values like %3a
+var percentEncodedValueRegex = /%[a-fA-F0-9]{2}/g;
+
+// The percent-encoding for the percent "%" character
+var percentEncodedPercent = "%25";
+
+function toUpper(str) { return str.toUpperCase(); }
+
+// Turns all percent-encoded values to upper case
+// "%3a" -> "%3A"
+function percentEncodedValuesToUpper(string) {
+  return string.replace(percentEncodedValueRegex, toUpper);
+}
+
+function decodeURIWithoutPercents(string) {
+  return string.split(percentEncodedPercent)
+               .map(decodeURI)
+               .join(percentEncodedPercent);
+}
+
+// Normalizes percent-encoded values to upper-case and decodes percent-encoded
+// values that are not reserved (like unicode characters).
+// Safe to call multiple times on the same path.
+function normalizePath(path) {
+  return decodeURIWithoutPercents(percentEncodedValuesToUpper(path));
+}
+
+// Normalizes percent-encoded values to upper-case and decodes percent-encoded
+// values that are not reserved (like unicode characters).
+// Safe to call multiple times on the same route.
+function normalizeRoute(route) {
+  return decodeURIWithoutPercents(percentEncodedValuesToUpper(route));
+}
+
+var Normalizer = {
+  normalizeRoute: normalizeRoute,
+  normalizePath: normalizePath
+};
+
+export default Normalizer;

--- a/lib/route-recognizer/normalizer.js
+++ b/lib/route-recognizer/normalizer.js
@@ -22,7 +22,9 @@ function decodeURIWithoutPercents(string) {
 // values that are not reserved (like unicode characters).
 // Safe to call multiple times on the same path.
 function normalizePath(path) {
-  return decodeURIWithoutPercents(percentEncodedValuesToUpper(path));
+  return path.split('/')
+             .map(normalizePathSegment)
+             .join('/');
 }
 
 // Normalizes percent-encoded values to upper-case and decodes percent-encoded
@@ -32,9 +34,49 @@ function normalizeRoute(route) {
   return decodeURIWithoutPercents(percentEncodedValuesToUpper(route));
 }
 
+function percentEncode(char) {
+  return '%' + charToHex(char);
+}
+
+function charToHex(char) {
+  return char.charCodeAt(0).toString(16).toUpperCase();
+}
+
+function decodeURIComponentExcept(string, reservedSet) {
+  string = percentEncodedValuesToUpper(string);
+  var replacements = {};
+  for (var i=0; i < reservedSet.length; i++) {
+    var char = reservedSet[i];
+    var pChar = percentEncode(char);
+    if (string.indexOf(pChar) !== -1) {
+      var replacement = "__" + charToHex(char) + "__";
+      replacements[pChar] = replacement;
+      string = string.replace(new RegExp(pChar, 'g'), replacement);
+    }
+  }
+  string = decodeURIComponent(string);
+
+  Object.keys(replacements).forEach(function(pChar) {
+    var replacement = replacements[pChar];
+    string = string.replace(new RegExp(replacement, 'g'), pChar);
+  });
+
+  return string;
+}
+
+function normalizeRouteSegment(segment) {
+  return decodeURIComponentExcept(segment, ['%', '/']);
+}
+
+function normalizePathSegment(segment) {
+  return decodeURIComponentExcept(segment, ['%', '/']);
+}
+
 var Normalizer = {
   normalizeRoute: normalizeRoute,
-  normalizePath: normalizePath
+  normalizeRouteSegment: normalizeRouteSegment,
+  normalizePath: normalizePath,
+  normalizePathSegment: normalizePathSegment
 };
 
 export default Normalizer;

--- a/tests/normalizer-tests.js
+++ b/tests/normalizer-tests.js
@@ -1,0 +1,44 @@
+/* globals QUnit */
+
+import RouteRecognizer from 'route-recognizer';
+
+var Normalizer = RouteRecognizer.Normalizer;
+
+module("Normalization");
+
+var expectations = [{
+  paths: ["/foo/bar"],
+  normalized: "/foo/bar"
+}, {
+  paths: ["/foo%3Abar", "/foo%3abar"],
+  normalized: "/foo:bar"
+}, {
+  paths: ["/foo%2fbar", "/foo%2Fbar"],
+  normalized: "/foo%2Fbar"
+}, {
+  paths: ["/café", "/caf%C3%A9", "/caf%c3%a9"],
+  normalized: "/café"
+}, {
+  paths: ["/abc%25def"],
+  normalized: "/abc%25def"
+}, {
+  paths: ["/" + encodeURIComponent("http://example.com/index.html?foo=100%&baz=boo#hash")],
+  normalized: "/http:%2F%2Fexample.com%2Findex.html?foo=100%25&baz=boo#hash"
+}, {
+  paths: ["/%25%25%25%25"],
+  normalized: "/%25%25%25%25"
+}, {
+  paths: ["/%25%25%25%25%3A%3a%2F%2f%2f"],
+  normalized: "/%25%25%25%25::%2F%2F%2F"
+}];
+
+expectations.forEach(function(expectation) {
+  var paths = expectation.paths;
+  var normalized = expectation.normalized;
+
+  paths.forEach(function(path) {
+    test("the path '" + path + "' is normalized to '" + normalized + "'", function() {
+      equal(Normalizer.normalizePath(path), normalized);
+    });
+  });
+});

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -20,14 +20,127 @@ test("A simple route recognizes", function() {
   equal(router.recognize("/foo/baz"), null);
 });
 
-test("A unicode route recognizes", function() {
-  var handler = {};
-  var router = new RouteRecognizer();
-  router.add([{ path: "/uniçø∂∑/ʇɥƃᴉɹlɐ", handler: handler }]);
+var slashStaticExpectations = [{
+  // leading slash
+  route: "/foo/bar",
+  matches: ["/foo/bar", "foo/bar", "foo/bar/"]
+}, {
+  // no leading or trailing slash
+  route: "foo/bar",
+  matches: ["/foo/bar", "foo/bar", "foo/bar/"]
+}, {
+  // trailing slash
+  route: "foo/bar/",
+  matches: ["/foo/bar", "foo/bar", "foo/bar/"]
+}, {
+  // leading and trailing slash
+  route: "/foo/bar/",
+  matches: ["/foo/bar", "foo/bar", "foo/bar/"]
+}];
 
-  var encoded = encodeURI("/uniçø∂∑/ʇɥƃᴉɹlɐ");
-  resultsMatch(router.recognize(encoded), [{ handler: handler, params: {}, isDynamic: false }]);
-  equal(router.recognize("/uniçø∂∑"), null);
+var nonAsciiStaticExpectations = [{
+  // uri-encoded path
+  route: "/foö/bär",
+  matches:  ["/foö/bär", "/fo%C3%B6/b%C3%A4r", "fo%c3%b6/b%c3%a4r"]
+}, {
+  // emoji
+  route: "/foo/😜",
+  matches: ["/foo/😜", "/foo/%F0%9F%98%9C"]
+}];
+
+// Tests for routes that include percent-encoded characters,
+// encoded and unencoded uri-reserved characters
+// (see http://www.ecma-international.org/ecma-262/6.0/#sec-uri-syntax-and-semantics),
+// unencoded non-uri-reserved characters (like " "),
+// and encoded percent char ("%")
+var encodedCharStaticExpectations = [{
+  // encoded uri-reserved char ":"
+  route: "/foo/%3Abar",
+  matches: ["/foo/%3Abar"],
+  nonmatches: ["/foo/:bar"]
+}, {
+  // unencoded ":" in non-significant place
+  route: "/foo/b:ar",
+  matches: ["/foo/b:ar"],
+  nonmatches: ["/foo/b%3Aar", "/foo/b%3aar"]
+  /* FIXME should this work?
+}, {
+  // encoded non-uri-reserved char "*" in significant place
+  route: "/foo/%2Abar",
+  matches: ["/foo/*bar", "/foo/%2Abar", "/foo/%2baar"]
+  */
+}, {
+  // unencoded "*" in non-significant place
+  route: "/foo/b*ar",
+  matches: ["/foo/b*ar", "/foo/b%2Aar", "/foo/b%2aar"]
+}, {
+  // unencoded " "
+  route: "/foo /bar",
+  matches: ["/foo /bar", "/foo%20/bar"]
+}, {
+  // encoded " "
+  route: "/foo%20/bar",
+  matches: ["/foo /bar", "/foo%20/bar"]
+}, {
+  // upper-case encoded uri-reserved char "/"
+  route: "/foo/ba%2Fr",
+  matches: ["/foo/ba%2Fr", "/foo/ba%2fr"], // match upper and lower-case
+  nonmatches: ["/foo/ba/r"]
+}, {
+  // lower-case encoded uri-reserved char "/"
+  route: "/foo/ba%2fr",
+  matches: ["/foo/ba%2Fr", "/foo/ba%2fr"],
+  nonmatches: ["/foo/ba/r"]
+}, {
+  // encoded special char "%" in route segment "ba%r"
+  route: "/foo/ba%25r",
+  matches: ["/foo/ba%25r"],
+  // nonmatches: ["/foo/ba%r"] // RouteRecognizer will throw malformed URI error
+}, {
+  // encoded non-uri-reserved char "*"
+  route: "/foo/ba%2Ar",
+  matches: ["/foo/ba%2Ar", "/foo/ba*r", "/foo/ba%2ar"]
+}, {
+  // encoded uri-reserved char "?"
+  route: "/foo/ba%3Fr",
+  matches: ["/foo/ba%3Fr", "/foo/ba%3fr"],
+  nonmatches: ["/foo/ba?r"]
+}, {
+  // encoded uri-reserved char "#" in route segment
+  route: "/foo/ba%23r",
+  matches: ["/foo/ba%23r"],
+  nonmatches: ["/foo/ba#r"]
+}];
+
+var staticExpectations = [].concat(slashStaticExpectations,
+                                   nonAsciiStaticExpectations,
+                                   encodedCharStaticExpectations);
+
+staticExpectations.forEach(function(expectation) {
+  var route, path, matches, nonmatches;
+  route = expectation.route;
+  matches = expectation.matches;
+  nonmatches = expectation.nonmatches || [];
+
+  matches.forEach(function(match) {
+    test("Static route '" + route + "' recognizes path '" + match + "'", function() {
+      var handler = {};
+      var router = new RouteRecognizer();
+      router.add([{ path: route, handler: handler }]);
+      resultsMatch(router.recognize(match), [{ handler: handler, params: {}, isDynamic: false }]);
+    });
+  });
+
+  if (nonmatches.length) {
+    nonmatches.forEach(function(nonmatch) {
+      test("Static route '" + route + "' does not recognize path '" + nonmatch + "'", function() {
+        var handler = {};
+        var router = new RouteRecognizer();
+        router.add([{ path: route, handler: handler }]);
+        equal(router.recognize(nonmatch), null);
+      });
+    });
+  }
 });
 
 test("A simple route with query params recognizes", function() {
@@ -102,7 +215,6 @@ test("A route with query params with pluses for spaces instead of %20 recognizes
   deepEqual(router.recognize("/foo/bar?++one+two=three+four+five++").queryParams, { '  one two': 'three four five  ' });
 });
 
-
 test("A `/` route recognizes", function() {
   var handler = {};
   var router = new RouteRecognizer();
@@ -129,6 +241,207 @@ test("A dynamic route recognizes", function() {
   equal(router.recognize("/zoo/baz"), null);
 });
 
+var nonAsciiDynamicExpectations = [{
+  paths: ["/foo/café", "/foo/caf%C3%A9", "/foo/caf%c3%a9"],
+  match: "café",
+  unencodedMatches: ["café", "café", "café"]
+}, {
+  paths: ["/foo/😜", "/foo/%F0%9F%98%9C"],
+  match: "😜",
+  unencodedMatches: ["😜", "😜"]
+}];
+
+var encodedCharDynamicExpectations = [{
+  // encoded "/", upper and lower
+  paths: ["/foo/ba%2Fr", "/foo/ba%2fr"],
+  match: "ba/r",
+  unencodedMatches: ["ba%2Fr", "ba%2fr"]
+}, {
+  // encoded "#"
+  paths: ["/foo/ba%23r"],
+  match: "ba#r",
+  unencodedMatches: ["ba%23r"]
+}, {
+  // ":"
+  paths: ["/foo/%3Abar", "/foo/%3abar", "/foo/:bar"],
+  match: ":bar",
+  unencodedMatches: ["%3Abar", "%3abar", ":bar"]
+}, {
+  // encoded "?"
+  paths: ["/foo/ba%3Fr", "/foo/ba%3fr"],
+  match: "ba?r",
+  unencodedMatches: ["ba%3Fr", "ba%3fr"]
+}, {
+  // space
+  paths: ["/foo/ba%20r", "/foo/ba r"],
+  match: "ba r",
+  // decodeURI changes "%20" -> " "
+  unencodedMatches: ["ba r", "ba r"]
+}, {
+  // "+"
+  paths: ["/foo/ba%2Br", "/foo/ba%2br", "/foo/ba+r"],
+  match: "ba+r",
+  unencodedMatches: ["ba%2Br", "ba%2br", "ba+r"]
+}, {
+  // encoded %
+  paths: ["/foo/ba%25r"],
+  match: "ba%r",
+  unencodedMatches: ["ba%r"]
+}, {
+  // many encoded %
+  paths: ["/foo/ba%25%25r%3A%25"],
+  match: "ba%%r:%",
+  unencodedMatches: ["ba%%r%3A%"]
+}, {
+  // doubly-encoded parameter
+  paths: ["/foo/" + encodeURIComponent("http://example.com/post/" + encodeURIComponent("http://other-url.com"))],
+  match: "http://example.com/post/" + encodeURIComponent("http://other-url.com"),
+  unencodedMatches: [encodeURIComponent("http://example.com/post/http://other-url.com")]
+}];
+
+var dynamicExpectations = [].concat(nonAsciiDynamicExpectations,
+                                    encodedCharDynamicExpectations);
+
+dynamicExpectations.forEach(function(expectation) {
+  var route = "/foo/:bar";
+  var paths = expectation.paths;
+  var match = expectation.match;
+  var unencodedMatches = expectation.unencodedMatches;
+
+  paths.forEach(function(path, index) {
+    var unencodedMatch = unencodedMatches[index];
+
+    test("Single-segment dynamic route '" + route + "' recognizes path '" + path + "'", function() {
+      var handler = {};
+      var router = new RouteRecognizer();
+      router.add([{ path: route, handler: handler }]);
+      resultsMatch(router.recognize(path), [{ handler: handler, params: { bar: match }, isDynamic: true }]);
+    });
+
+    test("When RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS is false, single-segment dynamic route '" + route + "' recognizes path '" + path + "'", function() {
+      RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = false;
+
+      var handler = {};
+      var router = new RouteRecognizer();
+      router.add([{ path: route, handler: handler }]);
+      resultsMatch(router.recognize(path), [{ handler: handler, params: { bar: unencodedMatch }, isDynamic: true }]);
+
+      RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = true;
+    });
+  });
+});
+
+var multiSegmentDynamicExpectations = [{
+  paths: ["/foo%20/bar/baz%20", "/foo /bar/baz "],
+  match: { foo: "foo ", baz: "baz " },
+  // " " is not a reserved uri character, so "%20" gets normalized to " "
+  // see http://www.ecma-international.org/ecma-262/6.0/#sec-uri-syntax-and-semantics
+  unencodedMatches: [{foo: "foo ", baz: "baz "},
+                     {foo: "foo ", baz: "baz "}]
+}, {
+  paths: ["/fo%25o/bar/ba%25z"],
+  match: { foo: "fo%o", baz: "ba%z" },
+  unencodedMatches: [{foo: "fo%o", baz: "ba%z"}]
+}, {
+  paths: ["/%3Afoo/bar/:baz%3a"],
+  match: {foo: ":foo", baz: ":baz:"},
+  // ":" is a reserved uri character, so "%3A" does not get normalized to ":"
+  unencodedMatches: [{foo: "%3Afoo", baz: ":baz%3a"}]
+}, {
+  paths: [encodeURIComponent("http://example.com/some_url.html?abc=foo") +
+          "/bar/" +
+          encodeURIComponent("http://example2.com/other.html#hash=bar")],
+  match: {
+    foo: "http://example.com/some_url.html?abc=foo",
+    baz: "http://example2.com/other.html#hash=bar"
+  },
+  unencodedMatches: [{
+    foo: decodeURI(encodeURIComponent("http://example.com/some_url.html?abc=foo")),
+    baz: decodeURI(encodeURIComponent("http://example2.com/other.html#hash=bar"))
+  }]
+}, {
+  paths: ["/föo/bar/bäz", "/f%c3%b6o/bar/b%c3%a4z", "/f%C3%B6o/bar/b%C3%A4z"],
+  match: {foo: "föo", baz: "bäz" },
+  unencodedMatches: [
+    {foo: "föo", baz: "bäz"},
+    {foo: "föo", baz: "bäz"},
+    {foo: "föo", baz: "bäz"}
+  ]
+}];
+
+multiSegmentDynamicExpectations.forEach(function(expectation) {
+  var route = "/:foo/bar/:baz";
+  var paths = expectation.paths;
+  var match = expectation.match;
+  var unencodedMatches = expectation.unencodedMatches;
+
+  paths.forEach(function(path, index) {
+    var unencodedMatch = unencodedMatches[index];
+
+    test("Multi-segment dynamic route '" + route + "' recognizes path '" + path + "'", function() {
+      var handler = {};
+      var router = new RouteRecognizer();
+      router.add([{ path: route, handler: handler }]);
+
+      resultsMatch(router.recognize(path), [{ handler: handler, params: match, isDynamic: true }]);
+    });
+
+    test("When RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS is false, multi-segment dynamic route '" + route + "' recognizes path '" + path + "'", function() {
+      RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = false;
+
+      var handler = {};
+      var router = new RouteRecognizer();
+      router.add([{ path: route, handler: handler }]);
+
+      resultsMatch(router.recognize(path), [{ handler: handler, params: unencodedMatch, isDynamic: true }]);
+
+      RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = true;
+    });
+  });
+});
+
+test("A dynamic route with unicode match parameters recognizes", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/:föo/bar/:bäz", handler: handler }]);
+  var path = "/foo/bar/baz";
+
+  var expectedParams = { föo: "foo", bäz: "baz" };
+  resultsMatch(router.recognize(path), [{ handler: handler, params: expectedParams, isDynamic: true }]);
+});
+
+var starExpectations = [
+  // encoded % is left encoded
+  "ba%25r",
+
+  // encoded / is left encoded
+  "ba%2Fr",
+
+  // multiple segments
+  "bar/baz/blah",
+
+  // trailing slash
+  "bar/baz/blah/",
+
+  // unencoded url
+  "http://example.com/abc_def.html",
+
+  // encoded url
+  encodeURIComponent("http://example.com/abc_%def.html")
+];
+
+starExpectations.forEach(function(value) {
+  var route = "/foo/*bar";
+  var path = "/foo/" + value;
+
+  test("Star segment glob route '" + route + "' recognizes path '" + path + '"', function() {
+    var handler = {};
+    var router = new RouteRecognizer();
+    router.add([{ path: route, handler: handler }]);
+    resultsMatch(router.recognize(path), [{ handler: handler, params: { bar: value }, isDynamic: true }]);
+  });
+});
+
 test("Multiple routes recognize", function() {
   var handler1 = { handler: 1 };
   var handler2 = { handler: 2 };
@@ -141,7 +454,7 @@ test("Multiple routes recognize", function() {
   resultsMatch(router.recognize("/bar/1"), [{ handler: handler2, params: { baz: "1" }, isDynamic: true }]);
 });
 
-test("ignore the URI malformed error", function() {
+test("query params ignore the URI malformed error", function() {
   var handler1 = { handler: 1 };
   var router = new RouteRecognizer();
 
@@ -194,7 +507,6 @@ test("Array query params do not conflict with controller namespaced query params
   ok(Array.isArray(p['foo[bar]']), "foo[bar] is an Array");
   deepEqual(p, {'foo[bar]': ["1","2"], 'baz': 'barf'});
 });
-
 
 test("Multiple `/` routes recognize", function() {
   var handler1 = { handler: 1 };
@@ -405,7 +717,7 @@ module("Route Generation", {
   setup: function() {
     router = new RouteRecognizer();
 
-    handlers = [ {}, {}, {}, {}, {}, {} ];
+    handlers = [ {}, {}, {}, {}, {}, {}, {} ];
 
     router.add([{ path: "/", handler: {} }], { as: "index" });
     router.add([{ path: "/posts/:id", handler: handlers[0] }], { as: "post" });
@@ -414,6 +726,7 @@ module("Route Generation", {
     router.add([{ path: "/posts/new", handler: handlers[2] }], { as: "new_post" });
     router.add([{ path: "/posts/:id/edit", handler: handlers[3] }], { as: "edit_post" });
     router.add([{ path: "/foo/:bar", handler: handlers[4] }, { path: "/baz/:bat", handler: handlers[5] }], { as: 'foo' });
+    router.add([{ path: "/*catchall", handler: handlers[5] }], { as: 'catchall' });
   }
 });
 
@@ -424,6 +737,81 @@ test("Generation works", function() {
   equal( router.generate("new_post"), "/posts/new" );
   equal( router.generate("edit_post", { id: 1 }), "/posts/1/edit" );
   equal( router.generate("postIndex"), "/posts" );
+  equal( router.generate("catchall", { catchall: "foo"}), "/foo" );
+});
+
+var encodedCharGenerationExpectations = [{
+  route: "post",
+  params: { id: "abc/def" },
+  expected: "/posts/abc%2Fdef",
+  expectedUnencoded: "/posts/abc/def"
+}, {
+  route: "post",
+  params: { id: "abc%def" },
+  expected: "/posts/abc%25def",
+  expectedUnencoded: "/posts/abc%def"
+}, {
+  route: "post",
+  params: { id: "abc def" },
+  expected: "/posts/abc%20def",
+  expectedUnencoded: "/posts/abc def"
+}, {
+  route: "post",
+  params: { id: "café" },
+  expected: "/posts/caf%C3%A9",
+  expectedUnencoded: "/posts/café"
+}, {
+  route: "edit_post",
+  params: { id: "abc/def" },
+  expected: "/posts/abc%2Fdef/edit",
+  expectedUnencoded: "/posts/abc/def/edit"
+}, {
+  route: "edit_post",
+  params: { id: "abc%def" },
+  expected: "/posts/abc%25def/edit",
+  expectedUnencoded: "/posts/abc%def/edit"
+}, {
+  route: "edit_post",
+  params: { id: "café" },
+  expected: "/posts/caf%C3%A9/edit",
+  expectedUnencoded: "/posts/café/edit"
+}];
+
+encodedCharGenerationExpectations.forEach(function(expectation) {
+  var route = expectation.route;
+  var params = expectation.params;
+  var expected = expectation.expected;
+  var expectedUnencoded = expectation.expectedUnencoded;
+
+  test("Encodes dynamic segment value for route '" + route + "' with params " + JSON.stringify(params), function() {
+    equal(router.generate(route, params), expected);
+  });
+
+  test("When RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS is false, does not encode dynamic segment for route '" + route + "' with params " + JSON.stringify(params), function() {
+    RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = false;
+    equal(router.generate(route, params), expectedUnencoded);
+    RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS = true;
+  });
+});
+
+var globGenerationValues = [
+  "abc/def",
+  "abc%2Fdef",
+  "abc def",
+  "abc%20def",
+  "abc%25def",
+  "café",
+  "caf%C3%A9",
+  "/leading-slash",
+  "leading-slash/",
+  "http://example.com/abc.html?foo=bar",
+  encodeURIComponent("http://example.com/abc.html?foo=bar")
+];
+
+globGenerationValues.forEach(function(value) {
+  test("Generating a star segment glob route with param '" + value + "' passes value through without modification", function() {
+    equal(router.generate("catchall", { catchall: value }), "/" + value);
+  });
 });
 
 test("Parsing and generation results into the same input string", function() {

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -877,10 +877,11 @@ test("Generating an invalid named route raises", function() {
 });
 
 test("Getting the handlers for a named route", function() {
-  deepEqual(router.handlersFor("post"), [ { handler: handlers[0], names: ['id'] } ]);
+  deepEqual(router.handlersFor("post"), [ { handler: handlers[0], names: [{name: 'id', decode: true}] } ]);
   deepEqual(router.handlersFor("posts"), [ { handler: handlers[1], names: [] } ]);
   deepEqual(router.handlersFor("new_post"), [ { handler: handlers[2], names: [] } ]);
-  deepEqual(router.handlersFor("edit_post"), [ { handler: handlers[3], names: ['id'] } ]);
+  deepEqual(router.handlersFor("edit_post"), [ { handler: handlers[3], names: [{name: 'id', decode: true}] } ]);
+  deepEqual(router.handlersFor("catchall"), [ { handler: handlers[5], names: [{name: 'catchall', decode: false}] } ]);
 });
 
 test("Getting a handler for an invalid named route raises", function() {

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -397,7 +397,7 @@ test("A dynamic route with unicode match parameters recognizes", function() {
   resultsMatch(router.recognize(path), [{ handler: handler, params: expectedParams, isDynamic: true }]);
 });
 
-var starExpectations = [
+var starSimpleExpectations = [
   // encoded % is left encoded
   "ba%25r",
 
@@ -417,7 +417,7 @@ var starExpectations = [
   encodeURIComponent("http://example.com/abc_%def.html")
 ];
 
-starExpectations.forEach(function(value) {
+starSimpleExpectations.forEach(function(value) {
   var route = "/foo/*bar";
   var path = "/foo/" + value;
 
@@ -426,6 +426,34 @@ starExpectations.forEach(function(value) {
     var router = new RouteRecognizer();
     router.add([{ path: route, handler: handler }]);
     resultsMatch(router.recognize(path), [{ handler: handler, params: { bar: value }, isDynamic: true }]);
+  });
+});
+
+var starComplexExpectations = [{
+  path: "/b%25ar/baz",
+  params: ["b%25ar", "baz"]
+}, {
+  path: "a/b/c/baz",
+  params: ["a/b/c", "baz"]
+}, {
+  path: "a%2Fb%2fc/baz",
+  params: ["a%2Fb%2fc", "baz"]
+}, {
+  path: encodeURIComponent("http://example.com") + "/baz",
+  params: [encodeURIComponent("http://example.com"), "baz"]
+}];
+
+starComplexExpectations.forEach(function(expectation) {
+  var route = "/*prefix/:suffix";
+  var path = expectation.path;
+  var params = { prefix: expectation.params[0], suffix: expectation.params[1] };
+
+  test("Complex star segment glob route '" + route + "' recognizes path '" + path + '"', function() {
+    var router = new RouteRecognizer();
+    var handler = {};
+    router.add([{ path: route, handler: handler }]);
+
+    resultsMatch(router.recognize(path), [{ handler: handler, params: params, isDynamic: true }]);
   });
 });
 


### PR DESCRIPTION
This PR supersedes #55. That PR originally attempted to encode/decode dynamic segments in matched paths, but it grew much larger when I attempted to make the solution robust in the face of dynamic segments with percent-encoded percent characters (`encodeURI("%") === "%25"`).

I'm approaching this PR in the spirit of an RFC, with a very detailed rationale for the changes below. If there is an alternative preferred approach for this large-ish change I'm happy to restructure or break apart this PR as necessary.

cc @krisselden 

## Changes to route-recognizer

Note about terminology:

  * **route** refers to a string that is added to the route recognizer (e.g.: the route in `router.add([{ path: '/foo/bar', ... }])` is `/foo/bar`)
  * **path** refers to a string that will be given to the route recognizer to recognize (e.g. the path in `router.recognize('/boo/baz')` is `/boo/baz`)
  * **match**/**matches** refers to when a path is recognized by the route recognizer (e.g. a route recognizer with route `/foo/:bar` would "match" the path `/foo/something`)
  * the route recognizer is also sometimes referred to as, simply, the **router**

### What is covered

This PR addresses the following:

  * Adds many tests for non-standard routes and paths (with percent-encodings and/or unicode characters)
  * Adds normalization for added routes and recognized paths to improve the matching of non-standard routes and paths
  * Fixes a bug where dynamic segments are not percent-encoded during generation
  * Fixes a bug where dynamic segments are not percent-decoded during recognition
  * Adds tests (and some code) to ensure that star segments in routes do *not* get decoded during recognition
  * Adds a flag that can be turned off by consumers to opt-out of the changes introduced here

### Who would be affected

It may only affect users who have routes with:

  * percent-encoded or unicode characters
  * dynamic segments that may match paths with percent-encoded characters
  * dynamic segments that are generated using values that have characters that should be encoded (e.g. forward slash: `/`)

It **may cause breaking changes** for users who have workarounds in place to encode/decode before generation/recognition. The breakage can be fixed by removing the workaround.

It will likely **not cause breaking changes** for users who have static routes with percent-encoded or unicode characters. All static route/path combinations that currently match will *also* match after this PR. Static routes that used to be considered distinct (e.g. `/f%20o` and `/f o`) are now normalized to the same thing. Users with affected static route/path combos likely need to do nothing; they may simply end up with superfluous routes that can be removed.

### Route and Path Normalization

The route-recognizer docs do not have a lot to say about routes with non-ascii and percent-encoded characters, so some of the work of this change is to add tests for many possible routes and expected matches that may exist in the wild.
The changes in this PR are intended to make the route-recognizer more likely to match routes that are added using either percent-encoded or non-encoded characters, and to recognize paths correctly whether they include percent-encoded characters or not.

The normalization added is intended to make the router recognize routes that:

  * are added with unicode characters (e.g. `/café`)
  * are added as percent-encoded strings (e.g. `/caf%C3%A9`)
  * are added with non-encoded "special" url characters (e.g. `/foo bar`, `/foo:bar`)
  * are added with percent-encoded "special" url characters (e.g. `/foo%20bar`, `/foo%3Abar`)
  * are recognized with paths containing percent-encoded unicode (e.g. `router.recognize('caf%C3%A9')`)
  * are recognized with paths containing non-percent-encoded unicode (e.g. `router.recognize('café')`)
  * are recognized with paths containing certain non-encoded "special" url characters (e.g., `router.recognize('foo bar')`, `router.recognize('foo:bar')`)
  * are recognized with paths containing certain percent-encoded "special" url characters (e.g., `router.recognize('foo%20bar')`, `router.recognize('foo%3Abar')`)

This adds a normalization step for routes when they are added (before they are parsed into segments) and paths when they are recognized.
Similar to the way one would lower-case two strings to check for case-insensitive equality, this normalization is intended to improve the recognition of
routes by ensuring there is a higher degree of similarity between routes and paths. All percent-encoded unicode characters and most percent-encoded special url characters
are normalized into equal strings, whether they are added as routes or recognized as paths.

### Normalization Steps:

The normalization for routes and paths is the same:
  * `decodeURI` the string *ignoring percent-encoded percent (`%`) characters* (i.e., *only* ignore the literal value: `%25`). This prevents an issue with encoded percent characters in dynamic segments, where they may be inadvertently doubly-decoded resulting in a URIError.
  * The decode call decodes any encoded unicode characters, so a route that is added as `/café` or `/caf%C3%A9` will be decoded to `/café` and will recognize the path `/café` or `/caf%C3%A9`
  * upper-case all remaining percent-encoded sequences (e.g. `%3a` -> `%3A`). That way these literal encoded sequences will still be matched. A route added as `"/fo%3a"` will be matched by incoming paths `"/fo%3a"` and `"/fo%3A"`

#### Normalization of URI-reserved characters

Characters in the `uriReserved` set (`; / ? : @ & = + $ ,`) are not encoded by `encodeURI`, and their percent-encodings (which should not be used in URLs, unless they are part of a dynamic segment) are likewise not decoded by `decodeURI` (e.g., `encodeURI(':') === ':'` and `decodeURI('%3A') === '%3A'`).

Since some of these characters have special meaning to the router dsl (`:` at the start of a segment) and to URLs (`?` indicating query params), they need to be encoded when adding them as routes (e.g., to add a route with the literal value ":" at the start of a segment it must be encoded: `router.add([{ path: "/foo/%3Abar" ...`).

#### Example affected static routes

Examples of static routes that *would* be affected by this change:

| static route | path | Old code matches? | New code matches ? | Note |
|--------------|--------------|-------------------|--------------------|------|
| `/fo%20`     | `/fo `       | N                 | Y                  | old code does not normalize route `/fo%20` |
| `/fo%20`     | `/fo%20`     | N                 | Y                  | old code `decodeURI`s path (to `/fo `) before recognizing against route `/fo%20` |
| `/fo%3a`     | `/fo%3A`     | N                 | Y                  | old code is case-sensitive for percent encodings |
| `/fo%25`     | `/fo%25`     | N                 | Y                  | percent-encoded `%` incorrectly decoded by old code |
| `/caf%C3%A9` | `/café`      | N                 | Y                  | old code does not normalize route |
| `/caf%C3%A9` | `/caf%C3%A9` | N                 | Y                  | old code does not normalize route but it does `decodeURI` path to `/café`, which doesn't match |

#### Example unaffected static routes
 
Examples of static routes that *would not* be affected by this change:

| static route | path | Old code matches? | New code matches ? | Note |
|-------------|----------|-------------------|--------------------|------|
| `/café`     | `/caf%C3A9`  | Y             | Y                  | old code `decodeURI`s the path (to `/café`) so it will be recognized |
| `/fo:`      | `/fo:`       | Y             | Y                  | exact match |
| `/fo `      | `/fo%20`     | Y             | Y                  | old code `decodeURI`s the path (to `/fo `) so it is recognized |
| `/fo `      | `/fo `       | Y             | Y                  | exact match |
| `/fo%3A`    | `/fo%3A`     | Y             | Y                  | exact match (`decodeURI('%3A') === '%3A'`) |
| `/fo%3A`    | `/fo:`       | N             | N                  | old and new code both don't change the `%3A` and `:` in route and path, respectively |
| `/café`     | `/café`      | Y             | Y                  | exact match |

### Dynamic Route Generation (bugfix)

Changes generation to call `encodeURIComponent` on dynamic route segments.
Previously, the parameter would be interpolated into the generated route *unchanged*.

This should be considered a *bugfix* because the previous behavior made it
possible for the router to generate a route that it later wouldn't be able to recognize.

It is a *breaking bugfix* for users that have workarounds in place to `encodeURIComponent`
their parameters before generating links from them. Those workarounds would lead to
doubly-encoded parameters in URLs.

#### Example route generation

Given a route with a dynamic segment: `"/post/:id"`, the following values of `id` will
generate the routes shown.

| `id` value  | Old route         | New route | Note  |
|-------------|-------------------|-----------|-------|
| `abc/def` | `/post/abc/def` | `/post/abc%2Fdef` | The old value is no longer recognizable by this route |
| `100%` | `/post/100%` | `/post/100%25` | The old value is an invalid URI |

### Dynamic Route Parameter Decoding (bugfix)

Changes route recognition to call `decodeURIComponent` on
recognized parameters from dynamic route segments.

Previously, the captured parameters would be returned unmodified. However, before
dynamic parameters are parsed, the `path` passed to `router.recognize` would be
"normalized" with `decodeURI` (to handle non-ascii unicode characters), so the
captured parameter was not always the same as the value in the `path`. See below.

The route-recognizer's docs do not discuss the expected behavior in these scenarios.
This change brings the behavior into closer alignment with behavior of other well-known
routers like the Rails router. As such, it could be considered either an *enhancement*
or a *bugfix*.

This is a *breaking* change for users that are working around this issue by calling `decodeURIComponent` on the params returned by the route. With the new code, this could result in unexpected values caused by double-decoding the value.

#### Example dynamic route parameter decoding

Given a route with a dynamic segment: `"/post/:id"`, the following paths will yield
the shown values for the `id` param.

| path              | Old `id` param | New `id` param | Note |
--------------------|----------------|----------------|------|
| `/post/abc%def"` | `abc%2Fdef`    | `abc/def`      | A user with a workaround would be unaffected. |
| `post/café`      | `café`         | `café`         |      |
| `post/caf%C3%A9` | `café`         | `café`         | the old code's call to `decodeURI(path)` decodes the percent-encoded `%C3A9` to `é`. A user with a workaround would be unaffected. |
| `post/%3A1`      | `%3A1`         | `:1`           | the old code's call to `decodeURI` does not decode `%3A` to `:`. A user with a workaround would be unaffected.     |
| `post/100%25`    | `100%`         | `100%`         | the old code's call to `decodeURI(path)` decodes `%25` to `%`. A user with a workaround in place would get an error when trying to `decodeURIComponent("100%")` |

#### Special case: doubly-encoded segments

The incorrect decoding of encoded percent characters also affects dynamic segments that have been mulitply encoded.
For example, if the post id is a url that itself has a `encodeURIComponent`-encoded parameter, such as:
````
let url = "http://example.com/post/" + encodeURIComponent("http://other-url.com")
let encodedUrl = encodeURIComponent(encodedUrl);
```

The reserved characters from "http://other-url.com" will be doubly-encoded in `encodedUrl`. E.g., the `//` in `http://other-url.com` is first encoded as `%2F%2F`,
and then the `%` characters are encoded again to `%25`: `encodeURIComponent(encodeURIComponent("//")) === "%252F%252F"`.

The old code would call `decodeURI` once on `encodedUrl`, resulting in the following (incorrect) value for id: `id === encodeURIComponent("http://example.com/post/http://other.url")`.
The new code avoids decoding the percent characters in the initial path, and it results in the following (correct) value for id: `id === "http://example.com/post/" + encodeURIComponent("http://other.url")`.

### Glob Routes (Star Segments)

This PR adds some tests and code to ensure that glob routes (e.g. `/*catchall`) do not decode their matching segments.
E.g., given the catchall route and path `/abc/foo%2Fbar`, the matched param `catchall` is `abc/foo%2Fbar`, not `abc/foo/bar`.
