### PR TITLE
Correctly parse complex objects

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -437,32 +437,85 @@ RouteRecognizer.prototype = {
   },
 
   parseQueryString: function(queryString) {
-    var pairs = queryString.split("&"), queryParams = {};
-    for(var i=0; i < pairs.length; i++) {
-      var pair      = pairs[i].split('='),
-          key       = decodeQueryParamPart(pair[0]),
-          keyLength = key.length,
-          isArray = false,
-          value;
-      if (pair.length === 1) {
-        value = 'true';
+    var queryParams = {};
+
+    // Iterate over all name=value pairs.
+    queryString.replace(/\+/g, ' ').split('&').forEach(function(v){
+      var param = v.split('='),
+      key = decodeQueryParamPart(param[0]),
+      val,
+      cur = queryParams,
+      i = 0,
+
+      // If key is more complex than 'foo', like 'a[]' or 'a[b][c]', split it
+      // into its component parts.
+      keys = key.split(']['),
+      keysLast = keys.length - 1;
+
+      // If the first keys part contains [ and the last ends with ], then []
+      // are correctly balanced.
+      if (/\[/.test(keys[0]) && /\]$/.test(keys[keysLast])) {
+        // Remove the trailing ] from the last keys part.
+        keys[keysLast] = keys[keysLast].replace(/\]$/, '');
+
+        // Split first keys part into two parts on the [ and add them back onto
+        // the beginning of the keys array.
+        keys = keys.shift().split('[').concat(keys);
+
+        keysLast = keys.length - 1;
       } else {
-        //Handle arrays
-        if (keyLength > 2 && key.slice(keyLength -2) === '[]') {
-          isArray = true;
-          key = key.slice(0, keyLength - 2);
-          if(!queryParams[key]) {
-            queryParams[key] = [];
+        // Basic 'foo' style key.
+        keysLast = 0;
+      }
+
+      // Are we dealing with a name=value pair, or just a name?
+      if (param.length === 2) {
+        val = decodeQueryParamPart(param[1]);
+
+        if (keysLast) {
+          // Complex key, build deep object structure based on a few rules:
+          // * The 'cur' pointer starts at the object top-level.
+          // * [] = array push (n is set to array length), [n] = array if n is
+          //   numeric, otherwise object.
+          // * If at the last keys part, set the value.
+          // * For each keys part, if the current level is undefined create an
+          //   object or array based on the type of the next keys part.
+          // * Move the 'cur' pointer to the next level.
+          // * Rinse & repeat.
+          for (; i <= keysLast; i++) {
+            key = keys[i] === '' ? cur.length : keys[i];
+            if (i < keysLast) {
+              cur = cur[key] = cur[key] || (keys[i+1] && isNaN(keys[i+1]) ? {} : []);
+            } else {
+              cur = cur[key] = val;
+            }
+          }
+
+        } else {
+          // Simple key, even simpler rules, since only scalars and shallow
+          // arrays are allowed.
+
+          if (isArray(queryParams[key])) {
+            // val is already an array, so push on the next value.
+            queryParams[key].push(val);
+
+          } else if ({}.hasOwnProperty.call(queryParams, key)) {
+            // val isn't an array, but since a second value has been specified,
+            // convert val into an array.
+            queryParams[key] = [queryParams[key], val];
+
+          } else {
+            // val is a scalar.
+            queryParams[key] = val;
           }
         }
-        value = pair[1] ? decodeQueryParamPart(pair[1]) : '';
+
+      } else if (key) {
+        // No value was defined, so set something meaningful.
+        queryParams[key] = 'true';
       }
-      if (isArray) {
-        queryParams[key].push(value);
-      } else {
-        queryParams[key] = value;
-      }
-    }
+    });
+
     return queryParams;
   },
 

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -102,6 +102,23 @@ test("A route with query params with pluses for spaces instead of %20 recognizes
   deepEqual(router.recognize("/foo/bar?++one+two=three+four+five++").queryParams, { '  one two': 'three four five  ' });
 });
 
+test("A route with query params with a complex encoded object recognizes", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/foo/bar", handler: handler}]);
+
+  var paramsObj = {
+    a: ['4','5','6'],
+    b: {
+      x: ['7'],
+      y: '8',
+      z: ['9','0','true','false','undefined','']
+    },
+    c: '1'
+  };
+  var qps = router.recognize("/foo/bar?a[]=4&a[]=5&a[]=6&b[x][]=7&b[y]=8&b[z][]=9&b[z][]=0&b[z][]=true&b[z][]=false&b[z][]=undefined&b[z][]=&c=1").queryParams;
+  deepEqual(qps, paramsObj);
+});
 
 test("A `/` route recognizes", function() {
   var handler = {};

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -208,8 +208,8 @@ test("Array query params do not conflict with controller namespaced query params
   router.add([{ path: "/foo/bar", handler: handler }]);
 
   var p = router.recognize("/foo/bar?foo[bar][]=1&foo[bar][]=2&baz=barf").queryParams;
-  ok(Array.isArray(p['foo[bar]']), "foo[bar] is an Array");
-  deepEqual(p, {'foo[bar]': ["1","2"], 'baz': 'barf'});
+  ok(Array.isArray(p.foo.bar), "foo[bar] is an Array");
+  deepEqual(p, { foo: { bar: ["1","2"] }, 'baz': 'barf'});
 });
 
 


### PR DESCRIPTION
I've found recently that route-recognizer doesn't have any support for object encoded in the URL.

Example using Ember:

Doing `store.query('foo', { filter: { name: 'John' } })` the generated URL (probably using `$.params` inside) looks like this `/foos?filter%5Bname%5D=John`.

However, route-recognizer is fed with this url, parses this `{ "filter[name]": "John" }` instead of 
`{ filter: { name: 'John' } }`.

I consider this a bug, since [$.deparam](https://github.com/AceMetrix/jquery-deparam) works as expected, and in the backend Rack also works as expected

``` rb
Rack::Utils.parse_nested_query("filter%5Bname%5D=John") #=> {"filter"=>{"name"=>"John"}}
```

This adds a failing test. I'll try to tackle this myself later today.
