### PR TITLE
Failing test for eliding routes.

### DIFF
--- a/tests/router-tests.js
+++ b/tests/router-tests.js
@@ -117,6 +117,20 @@ test("supports deeply nested handlers", function() {
   matchesRoute("/posts/edit", [{ handler: "posts", params: {}, isDynamic: false }, { handler: "editPost", params: {}, isDynamic: false }]);
 });
 
+test("matches order properly for eliding route definitions", function() {
+  router.map(function(match) {
+    match("/posts", function(match) {
+      match("/new").to("new");
+    });
+    match("/posts").to("posts", function(match) {
+      match("/4").to("handler4");
+    });
+    match("/posts/4").to("nohandler4");
+  });
+
+  matchesRoute("/posts/4", [{ handler: "posts", params: {}, isDynamic: false }, { handler: "handler4", params: {}, isDynamic: false }]);
+});
+
 test("supports index-style routes", function() {
   router.map(function(match) {
     match("/posts").to("posts", function(match) {


### PR DESCRIPTION
When you elide routes in route-recognizer, the last one in always wins. Further, if that route has different arrangements with its handlers those differences are not accounted for. 

The correct behavior is not specified, however, I believe that since routes are added "in order," and that order matters for specificity, that the correct behavior is FIFO, making this failing test correct.

Thoughts?

<img width="283" alt="screen shot 2016-05-13 at 8 57 46 pm" src="https://cloud.githubusercontent.com/assets/20542/15266067/a9e783f6-194d-11e6-987d-3df3061ecc6a.png">