### PR TITLE
failing dynamic-versus-glob specificity est fix

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -156,6 +156,11 @@ function parse(route, names, specificity, shouldDecodes) {
   return results;
 }
 
+function isEqualCharSpec(specA, specB) {
+  return specA.validChars === specB.validChars &&
+         specA.invalidChars === specB.invalidChars;
+}
+
 // A State has a character specification and (`charSpec`) and a list of possible
 // subsequent states (`nextStates`).
 //
@@ -176,7 +181,6 @@ function parse(route, names, specificity, shouldDecodes) {
 function State(charSpec) {
   this.charSpec = charSpec;
   this.nextStates = [];
-  this.charSpecs = {};
   this.regex = undefined;
   this.handlers = undefined;
   this.specificity = undefined;
@@ -184,20 +188,12 @@ function State(charSpec) {
 
 State.prototype = {
   get: function(charSpec) {
-    if (this.charSpecs[charSpec.validChars]) {
-      return this.charSpecs[charSpec.validChars];
-    }
-
     var nextStates = this.nextStates;
 
     for (var i=0; i<nextStates.length; i++) {
       var child = nextStates[i];
 
-      var isEqual = child.charSpec.validChars === charSpec.validChars;
-      isEqual = isEqual && child.charSpec.invalidChars === charSpec.invalidChars;
-
-      if (isEqual) {
-        this.charSpecs[charSpec.validChars] = child;
+      if (isEqualCharSpec(child.charSpec, charSpec)) {
         return child;
       }
     }

--- a/tests/router-tests.js
+++ b/tests/router-tests.js
@@ -60,6 +60,31 @@ test("supports nested match", function() {
   matchesRoute("/posts/edit", [{ handler: "editPost", params: {}, isDynamic: false }]);
 });
 
+test("support nested dynamic routes and star route", function() {
+  router.map(function(match) {
+    match("/:routeId").to("routeId", function(match) {
+      match("/").to("routeId.index");
+      match("/:subRouteId").to("subRouteId");
+    });
+    match("/*wildcard").to("wildcard");
+  });
+
+  // fails because it incorrectly matches the wildcard route
+  matchesRoute("/abc", [
+    {handler: "routeId", params: { routeId: "abc" }, isDynamic: true},
+    {handler: "routeId.index", params: {}, isDynamic: false},
+  ]);
+
+  // passes
+  matchesRoute("/abc/def", [
+    {handler: "routeId", params: {routeId: "abc"}, isDynamic: true},
+    {handler: "subRouteId", params: {"subRouteId": "def"}, isDynamic: true}
+  ]);
+
+  // fails because no route is recognized
+  matchesRoute("/abc/def/ghi", [{handler: "wildcard", params: { wildcard: "abc/def/ghi"}, isDynamic: true}]);
+});
+
 test("supports nested match with query params", function() {
   router.map(function(match) {
     match("/posts", function(match) {


### PR DESCRIPTION
re: https://github.com/tildeio/route-recognizer/pull/100
re: https://github.com/emberjs/ember.js/issues/13921

/cc @bantic @nathanhammond @jmeas @derrickshowers

It appears if two `charSpec`s share the same `validChars` (as dynamic segments and wildcards do, both `undefined`) then a later addition will stomp a pre-existing state. In this fix I've gotten more strict about equality (you can see in the code descending into child routes where it was already more exacting) and made this test pass, however I'm concerned about continuing to use `validChars` as a key for the cache of next states. It seems silly to even bother with the map when we can probably iterate just as fast. If iteration is too slow, then we should at least use a composite key with both `validChars` and `invalidChars`.