### PR TITLE
Build up specificity for nested routes.

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -125,10 +125,7 @@ function parse(route, names, specificity, shouldDecodes) {
   // `x`, irrespective of the other parts.
   // Because of this similarity, we assign each type of segment a number value written as a
   // string. We can find the specificity of compound routes by concatenating these strings
-  // together, from left to right. After we have looped through all of the segments,
-  // we convert the string to a number.
-  specificity.val = '';
-
+  // together, from left to right.
   for (var i=0; i<segments.length; i++) {
     var segment = segments[i], match;
 
@@ -150,8 +147,6 @@ function parse(route, names, specificity, shouldDecodes) {
       specificity.val += '4';
     }
   }
-
-  specificity.val = +specificity.val;
 
   return results;
 }
@@ -249,7 +244,7 @@ State.prototype = {
 // Sort the routes by specificity
 function sortSolutions(states) {
   return states.sort(function(a, b) {
-    return b.specificity.val - a.specificity.val;
+    return (b.specificity.val < a.specificity.val) ? -1 : (b.specificity.val === a.specificity.val) ? 0 : 1;
   });
 }
 
@@ -337,7 +332,7 @@ var RouteRecognizer = function() {
 RouteRecognizer.prototype = {
   add: function(routes, options) {
     var currentState = this.rootState, regex = "^",
-        specificity = {},
+        specificity = { val: '' },
         handlers = new Array(routes.length), allSegments = [], name;
 
     var isEmpty = true;

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -889,3 +889,59 @@ test("Getting a handler for an invalid named route raises", function() {
         router.handlersFor("nope");
     }, /There is no route named nope/);
 });
+
+test("Matches the route with the longer static prefix", function() {
+  var handler1 = { handler: 1 };
+  var handler2 = { handler: 2 };
+  var router = new RouteRecognizer();
+
+  router.add([{ path: "/static", handler: handler2 }, { path: "/", handler: handler2 }]);
+  router.add([{ path: "/:dynamic", handler: handler1 }, { path: "/", handler: handler1 }]);
+
+  resultsMatch(router.recognize("/static"), [
+    { handler: handler2, params: { }, isDynamic: false },
+    { handler: handler2, params: { }, isDynamic: false }
+  ]);
+});
+
+// Re: https://github.com/emberjs/ember.js/issues/13960
+test("Matches the route with the longer static prefix with nesting", function() {
+  var handler1 = { handler: 1 };
+  var handler2 = { handler: 2 };
+  var handler3 = { handler: 3 };
+  var router = new RouteRecognizer();
+
+  router.add([
+    { path: "/", handler: handler1 }, /* application route */
+    { path: "/", handler: handler1 }, /* posts route */
+    { path: ":post_id", handler: handler1 }
+  ]);
+  router.add([
+    { path: "/", handler: handler3 }, /* application route */
+    { path: "/team", handler: handler3 },
+    { path: ":user_slug", handler: handler3 }
+  ]);
+  router.add([
+    { path: "/", handler: handler2 }, /* application route */
+    { path: "/team", handler: handler2 },
+    { path: "/", handler: handler2 } /* index route */
+  ]);
+
+  resultsMatch(router.recognize("/5"), [
+    { handler: handler1, params: { }, isDynamic: false },
+    { handler: handler1, params: { }, isDynamic: false },
+    { handler: handler1, params: { post_id: '5' }, isDynamic: true }
+  ]);
+
+  resultsMatch(router.recognize("/team"), [
+    { handler: handler2, params: { }, isDynamic: false },
+    { handler: handler2, params: { }, isDynamic: false },
+    { handler: handler2, params: { }, isDynamic: false }
+  ]);
+ 
+  resultsMatch(router.recognize("/team/eww_slugs"), [
+    { handler: handler3, params: { }, isDynamic: false },
+    { handler: handler3, params: { }, isDynamic: false },
+    { handler: handler3, params: { user_slug: 'eww_slugs' }, isDynamic: true }
+  ]);
+});


### PR DESCRIPTION
When adding an array of routes, each route will increase the
specificity instead of using only that of the last route.

Resolves #102.
