### PR TITLE
Revert specificity changes in PR #46

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -100,34 +100,13 @@ EpsilonSegment.prototype = {
 // The `names` will be populated with the paramter name for each dynamic/star
 // segment. `shouldDecodes` will be populated with a boolean for each dyanamic/star
 // segment, indicating whether it should be decoded during recognition.
-function parse(route, names, specificity, shouldDecodes) {
+function parse(route, names, types, shouldDecodes) {
   // normalize route as not starting with a "/". Recognition will
   // also normalize.
   if (route.charAt(0) === "/") { route = route.substr(1); }
 
   var segments = route.split("/");
   var results = new Array(segments.length);
-
-  // A routes has specificity determined by the order that its different segments
-  // appear in. This system mirrors how the magnitude of numbers written as strings
-  // works.
-  // Consider a number written as: "abc". An example would be "200". Any other number written
-  // "xyz" will be smaller than "abc" so long as `a > x`. For instance, "199" is smaller
-  // then "200", even though "y" and "z" (which are both 9) are larger than "0" (the value
-  // of (`b` and `c`). This is because the leading symbol, "2", is larger than the other
-  // leading symbol, "1".
-  // The rule is that symbols to the left carry more weight than symbols to the right
-  // when a number is written out as a string. In the above strings, the leading digit
-  // represents how many 100's are in the number, and it carries more weight than the middle
-  // number which represents how many 10's are in the number.
-  // This system of number magnitude works well for route specificity, too. A route written as
-  // `a/b/c` will be more specific than `x/y/z` as long as `a` is more specific than
-  // `x`, irrespective of the other parts.
-  // Because of this similarity, we assign each type of segment a number value written as a
-  // string. We can find the specificity of compound routes by concatenating these strings
-  // together, from left to right. After we have looped through all of the segments,
-  // we convert the string to a number.
-  specificity.val = '';
 
   for (var i=0; i<segments.length; i++) {
     var segment = segments[i], match;
@@ -136,22 +115,19 @@ function parse(route, names, specificity, shouldDecodes) {
       results[i] = new DynamicSegment(match[1]);
       names.push(match[1]);
       shouldDecodes.push(true);
-      specificity.val += '3';
+      types.dynamics++;
     } else if (match = segment.match(/^\*([^\/]+)$/)) {
       results[i] = new StarSegment(match[1]);
       names.push(match[1]);
       shouldDecodes.push(false);
-      specificity.val += '1';
+      types.stars++;
     } else if(segment === "") {
       results[i] = new EpsilonSegment();
-      specificity.val += '2';
     } else {
       results[i] = new StaticSegment(segment);
-      specificity.val += '4';
+      types.statics++;
     }
   }
-
-  specificity.val = +specificity.val;
 
   return results;
 }
@@ -246,10 +222,29 @@ State.prototype = {
   }
 };
 
-// Sort the routes by specificity
+// This is a somewhat naive strategy, but should work in a lot of cases
+// A better strategy would properly resolve /posts/:id/new and /posts/edit/:id.
+//
+// This strategy generally prefers more static and less dynamic matching.
+// Specifically, it
+//
+//  * prefers fewer stars to more, then
+//  * prefers using stars for less of the match to more, then
+//  * prefers fewer dynamic segments to more, then
+//  * prefers more static segments to more
 function sortSolutions(states) {
   return states.sort(function(a, b) {
-    return b.specificity.val - a.specificity.val;
+    if (a.types.stars !== b.types.stars) { return a.types.stars - b.types.stars; }
+
+    if (a.types.stars) {
+      if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
+      if (a.types.dynamics !== b.types.dynamics) { return b.types.dynamics - a.types.dynamics; }
+    }
+
+    if (a.types.dynamics !== b.types.dynamics) { return a.types.dynamics - b.types.dynamics; }
+    if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
+
+    return 0;
   });
 }
 
@@ -337,7 +332,7 @@ var RouteRecognizer = function() {
 RouteRecognizer.prototype = {
   add: function(routes, options) {
     var currentState = this.rootState, regex = "^",
-        specificity = {},
+        types = { statics: 0, dynamics: 0, stars: 0 },
         handlers = new Array(routes.length), allSegments = [], name;
 
     var isEmpty = true;
@@ -345,7 +340,7 @@ RouteRecognizer.prototype = {
     for (var i=0; i<routes.length; i++) {
       var route = routes[i], names = [], shouldDecodes = [];
 
-      var segments = parse(route.path, names, specificity, shouldDecodes);
+      var segments = parse(route.path, names, types, shouldDecodes);
 
       allSegments = allSegments.concat(segments);
 
@@ -375,7 +370,7 @@ RouteRecognizer.prototype = {
 
     currentState.handlers = handlers;
     currentState.regex = new RegExp(regex + "$");
-    currentState.specificity = specificity;
+    currentState.types = types;
 
     if (name = options && options.as) {
       this.names[name] = {

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -648,6 +648,16 @@ test("Nested routes recognize", function() {
   equal(router.hasRoute('bar'), false);
 });
 
+test("Nested epsilon routes recognize.", function() {
+  var router = new RouteRecognizer();
+  router.add([{"path":"/","handler":"application"},{"path":"/","handler":"test1"},{"path":"/test2","handler":"test1.test2"}]);
+  router.add([{"path":"/","handler":"application"},{"path":"/","handler":"test1"},{"path":"/","handler":"test1.index"}]);
+  router.add([{"path":"/","handler":"application"},{"path":"/","handler":"test1"},{"path":"/","handler":"test1.index"}]);
+  router.add([{"path":"/","handler":"application"},{"path":"/:param","handler":"misc"}], {"as":"misc"});
+
+  resultsMatch(router.recognize("/test2"), [{ "handler": "application", "isDynamic": false, "params": {} }, { "handler": "test1", "isDynamic": false, "params": {} }, { "handler": "test1.test2", "isDynamic": false, "params": {} }]);
+});
+
 test("Nested routes with query params recognize", function() {
   var handler1 = { handler: 1 };
   var handler2 = { handler: 2 };
@@ -888,4 +898,60 @@ test("Getting a handler for an invalid named route raises", function() {
     QUnit.throws(function() {
         router.handlersFor("nope");
     }, /There is no route named nope/);
+});
+
+test("Matches the route with the longer static prefix", function() {
+  var handler1 = { handler: 1 };
+  var handler2 = { handler: 2 };
+  var router = new RouteRecognizer();
+
+  router.add([{ path: "/static", handler: handler2 }, { path: "/", handler: handler2 }]);
+  router.add([{ path: "/:dynamic", handler: handler1 }, { path: "/", handler: handler1 }]);
+
+  resultsMatch(router.recognize("/static"), [
+    { handler: handler2, params: { }, isDynamic: false },
+    { handler: handler2, params: { }, isDynamic: false }
+  ]);
+});
+
+// Re: https://github.com/emberjs/ember.js/issues/13960
+test("Matches the route with the longer static prefix with nesting", function() {
+  var handler1 = { handler: 1 };
+  var handler2 = { handler: 2 };
+  var handler3 = { handler: 3 };
+  var router = new RouteRecognizer();
+
+  router.add([
+    { path: "/", handler: handler1 }, /* application route */
+    { path: "/", handler: handler1 }, /* posts route */
+    { path: ":post_id", handler: handler1 }
+  ]);
+  router.add([
+    { path: "/", handler: handler3 }, /* application route */
+    { path: "/team", handler: handler3 },
+    { path: ":user_slug", handler: handler3 }
+  ]);
+  router.add([
+    { path: "/", handler: handler2 }, /* application route */
+    { path: "/team", handler: handler2 },
+    { path: "/", handler: handler2 } /* index route */
+  ]);
+
+  resultsMatch(router.recognize("/5"), [
+    { handler: handler1, params: { }, isDynamic: false },
+    { handler: handler1, params: { }, isDynamic: false },
+    { handler: handler1, params: { post_id: '5' }, isDynamic: true }
+  ]);
+
+  resultsMatch(router.recognize("/team"), [
+    { handler: handler2, params: { }, isDynamic: false },
+    { handler: handler2, params: { }, isDynamic: false },
+    { handler: handler2, params: { }, isDynamic: false }
+  ]);
+
+  resultsMatch(router.recognize("/team/eww_slugs"), [
+    { handler: handler3, params: { }, isDynamic: false },
+    { handler: handler3, params: { }, isDynamic: false },
+    { handler: handler3, params: { user_slug: 'eww_slugs' }, isDynamic: true }
+  ]);
 });

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -569,29 +569,6 @@ test("Prefers single dynamic segments over stars", function() {
   resultsMatch(router.recognize("/foo/bar/suffix"), [{ handler: handler2, params: { star: "bar", dynamic: "suffix" }, isDynamic: true }]);
 });
 
-test("Prefers more specific routes over less specific routes", function() {
-  var handler1 = { handler: 1 };
-  var handler2 = { handler: 2 };
-  var router = new RouteRecognizer();
-
-  router.add([{ path: "/foo/:dynamic/baz", handler: handler1 }]);
-  router.add([{ path: "/foo/bar/:dynamic", handler: handler2 }]);
-
-  resultsMatch(router.recognize("/foo/bar/baz"), [{ handler: handler2, params: { dynamic: "baz" }, isDynamic: true }]);
-  resultsMatch(router.recognize("/foo/3/baz"), [{ handler: handler1, params: { dynamic: "3" }, isDynamic: true }]);
-});
-
-test("Prefers more specific routes with stars over less specific dynamic routes", function() {
-  var handler1 = { handler: 1 };
-  var handler2 = { handler: 2 };
-  var router = new RouteRecognizer();
-
-  router.add([{ path: "/foo/*star", handler: handler1 }]);
-  router.add([{ path: "/:dynamicOne/:dynamicTwo", handler: handler2 }]);
-
-  resultsMatch(router.recognize("/foo/bar"), [{ handler: handler1, params: { star: "bar" }, isDynamic: true }]);
-});
-
 test("Handle star routes last when there are trailing `/` routes.", function() {
   var handler1 = { handler: 1 };
   var handler2 = { handler: 2 };


### PR DESCRIPTION
https://github.com/tildeio/route-recognizer/pull/46 changed the specificity system used in route-recognizer to be much simpler, however the simpler implementation also lost some behaviors expected be real-world Ember apps. This introduces a test for such a case as reported in https://github.com/emberjs/ember.js/issues/13960 and rolls back the changes from #46.