### PR TITLE
Do not encode chars that are allowed in path segments

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -3,6 +3,7 @@ import Normalizer from './route-recognizer/normalizer';
 
 var normalizePath = Normalizer.normalizePath;
 var normalizeSegment = Normalizer.normalizeSegment;
+var encodePathSegment = Normalizer.encodePathSegment;
 
 var specials = [
   '/', '.', '*', '+', '?', '|',
@@ -66,7 +67,7 @@ DynamicSegment.prototype = {
 
   generate: function(params) {
     if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS) {
-      return encodeURIComponent(params[this.name]);
+      return encodePathSegment(params[this.name]);
     } else {
       return params[this.name];
     }

--- a/lib/route-recognizer/normalizer.js
+++ b/lib/route-recognizer/normalizer.js
@@ -74,9 +74,51 @@ function normalizeSegment(segment) {
   return decodeURIComponentExcept(segment, reservedHex);
 }
 
+function encodeURIComponentExcept(string, reservedChars) {
+  var pieces       = [];
+  var separators   = [];
+  var currentPiece = '';
+  var idx;
+
+  for (idx=0; idx < string.length; idx++) {
+    var char = string[idx];
+    if (reservedChars.indexOf(char) === -1) {
+      currentPiece += char;
+    } else {
+      pieces.push(currentPiece);
+      separators.push(char);
+      currentPiece = '';
+    }
+  }
+  if (currentPiece.length) {
+    pieces.push(currentPiece);
+    separators.push('');
+  }
+
+  pieces = pieces.map(encodeURIComponent);
+  var encoded = '';
+  for (idx = 0; idx < pieces.length; idx++) {
+    encoded += pieces[idx] + separators[idx];
+  }
+
+  return encoded;
+}
+
+// Do not encode these characters when generating dynamic path segments
+// See https://tools.ietf.org/html/rfc3986#section-3.3
+var reservedSegmentChars = [
+  "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "=", // sub-delims
+  ":", "@" // others explicitly allowed by RFC 3986
+];
+function encodePathSegment(segment) {
+  segment = '' + segment; // coerce to string
+  return encodeURIComponentExcept(segment, reservedSegmentChars);
+}
+
 var Normalizer = {
   normalizeSegment: normalizeSegment,
-  normalizePath: normalizePath
+  normalizePath: normalizePath,
+  encodePathSegment: encodePathSegment
 };
 
 export default Normalizer;


### PR DESCRIPTION
During route generation for dynamic segments, do not percent-encode
characters that, according to RFC 3986, are allowed in path segments.

RFC 3986 defines "sub-delims" (these chars: `! $ & ' ( ) * + , ; =`) and
specifies that they along with `:` and `@` do not need to be encoded in path segments
in URIs. See: https://tools.ietf.org/html/rfc3986#section-3.3

This commit changes RouteRecognizer'ss generation code for dynamic
segments to explicitly avoid encoding those characters.

Fixes https://github.com/emberjs/ember.js/issues/14094