### PR TITLE
Use a regex in `encodePathSegment`

### DIFF
--- a/lib/route-recognizer/normalizer.js
+++ b/lib/route-recognizer/normalizer.js
@@ -74,45 +74,20 @@ function normalizeSegment(segment) {
   return decodeURIComponentExcept(segment, reservedHex);
 }
 
-function encodeURIComponentExcept(string, reservedChars) {
-  var pieces       = [];
-  var separators   = [];
-  var currentPiece = '';
-  var idx;
-
-  for (idx=0; idx < string.length; idx++) {
-    var char = string[idx];
-    if (reservedChars.indexOf(char) === -1) {
-      currentPiece += char;
-    } else {
-      pieces.push(currentPiece);
-      separators.push(char);
-      currentPiece = '';
-    }
-  }
-  if (currentPiece.length) {
-    pieces.push(currentPiece);
-    separators.push('');
-  }
-
-  pieces = pieces.map(encodeURIComponent);
-  var encoded = '';
-  for (idx = 0; idx < pieces.length; idx++) {
-    encoded += pieces[idx] + separators[idx];
-  }
-
-  return encoded;
-}
-
-// Do not encode these characters when generating dynamic path segments
+// We do not want to encode these characters when generating dynamic path segments
 // See https://tools.ietf.org/html/rfc3986#section-3.3
-var reservedSegmentChars = [
-  "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "=", // sub-delims
-  ":", "@" // others explicitly allowed by RFC 3986
-];
-function encodePathSegment(segment) {
-  segment = '' + segment; // coerce to string
-  return encodeURIComponentExcept(segment, reservedSegmentChars);
+// sub-delims: "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "="
+// others allowed by RFC 3986: ":", "@"
+//
+// First encode the entire path segment, then decode any of the encoded special chars.
+//
+// The chars "!", "'", "(", ")", "*" do not get changed by `encodeURIComponent`,
+// so the possible encoded chars are:
+// ['%24', '%26', '%2B', '%2C', '%3B', '%3D', '%3A', '$40'].
+var PATH_SEGMENT_ENCODINGS = /%(?:24|26|2B|2C|3B|3D|3A|40)/g;
+
+function encodePathSegment(str) {
+  return encodeURIComponent(str).replace(PATH_SEGMENT_ENCODINGS, decodeURIComponent);
 }
 
 var Normalizer = {


### PR DESCRIPTION
This approach is much simpler than walking the string, and appears to be
at least as performant as the previous.

Refs #109 

cc @nathanhammond