### PR TITLE
Refactor `normalizeSegment` to avoid walking the string

### DIFF
--- a/lib/route-recognizer/normalizer.js
+++ b/lib/route-recognizer/normalizer.js
@@ -1,15 +1,6 @@
-// Match percent-encoded values (e.g. %3a, %3A, %25)
-var PERCENT_ENCODED_VALUES = /%[a-fA-F0-9]{2}/g;
-
-function toUpper(str) { return str.toUpperCase(); }
-
-// Turn percent-encoded values to upper case ("%3a" -> "%3A")
-function percentEncodedValuesToUpper(string) {
-  return string.replace(PERCENT_ENCODED_VALUES, toUpper);
-}
-
-// Normalizes percent-encoded values to upper-case and decodes percent-encoded
-// values that are not reserved (like unicode characters).
+// Normalizes percent-encoded values in `path` to upper-case and decodes percent-encoded
+// values that are not reserved (i.e., unicode characters, emoji, etc). The reserved
+// chars are "/" and "%".
 // Safe to call multiple times on the same path.
 function normalizePath(path) {
   return path.split('/')
@@ -17,61 +8,12 @@ function normalizePath(path) {
              .join('/');
 }
 
-function percentEncode(char) {
-  return '%' + charToHex(char);
-}
-
-function charToHex(char) {
-  return char.charCodeAt(0).toString(16).toUpperCase();
-}
-
-// Decodes percent-encoded values in the string except those
-// characters in `reservedHex`, where `reservedHex` is an array of 2-character
-// percent-encodings
-function decodeURIComponentExcept(string, reservedHex) {
-  if (string.indexOf('%') === -1) {
-    // If there is no percent char, there is no decoding that needs to
-    // be done and we exit early
-    return string;
-  }
-  string = percentEncodedValuesToUpper(string);
-
-  var result = '';
-  var buffer = '';
-  var idx = 0;
-  while (idx < string.length) {
-    var pIdx = string.indexOf('%', idx);
-
-    if (pIdx === -1) { // no percent char
-      buffer += string.slice(idx);
-      break;
-    } else { // found percent char
-      buffer += string.slice(idx, pIdx);
-      idx = pIdx + 3;
-
-      var hex = string.slice(pIdx + 1, pIdx + 3);
-      var encoded = '%' + hex;
-
-      if (reservedHex.indexOf(hex) === -1) {
-        // encoded is not in reserved set, add to buffer
-        buffer += encoded;
-      } else {
-        result += decodeURIComponent(buffer);
-        buffer = '';
-        result += encoded;
-      }
-    }
-  }
-  result += decodeURIComponent(buffer);
-  return result;
-}
-
-// Leave these characters in encoded state in segments
-var reservedSegmentChars = ['%', '/'];
-var reservedHex = reservedSegmentChars.map(charToHex);
-
+// We want to ensure the characters "%" and "/" remain in percent-encoded
+// form when normalizing paths, so replace them with their encoded form after
+// decoding the rest of the path
+var SEGMENT_RESERVED_CHARS = /%|\//g;
 function normalizeSegment(segment) {
-  return decodeURIComponentExcept(segment, reservedHex);
+  return decodeURIComponent(segment).replace(SEGMENT_RESERVED_CHARS, encodeURIComponent);
 }
 
 // We do not want to encode these characters when generating dynamic path segments
@@ -83,7 +25,7 @@ function normalizeSegment(segment) {
 //
 // The chars "!", "'", "(", ")", "*" do not get changed by `encodeURIComponent`,
 // so the possible encoded chars are:
-// ['%24', '%26', '%2B', '%2C', '%3B', '%3D', '%3A', '$40'].
+// ['%24', '%26', '%2B', '%2C', '%3B', '%3D', '%3A', '%40'].
 var PATH_SEGMENT_ENCODINGS = /%(?:24|26|2B|2C|3B|3D|3A|40)/g;
 
 function encodePathSegment(str) {


### PR DESCRIPTION
Use a regex instead to replace any characters that shouldn't be decoded
(`%` and `/`) with their encoded form after decoding the rest of the
string.

As suggested via @krisselden in https://embercommunity.slack.com/?redir=%2Farchives%2Fdev-router%2Fp1471896246000705. cc @nathanhammond 