### PR TITLE
Trailing slashes with encoded characters.

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -513,7 +513,7 @@ RouteRecognizer.prototype = {
     pathLen = path.length;
     if (pathLen > 1 && path.charAt(pathLen - 1) === "/") {
       path = path.substr(0, pathLen - 1);
-      originalPath = originalPath.substr(0, pathLen - 1);
+      originalPath = originalPath.substr(0, originalPath.length - 1);
       isSlashDropped = true;
     }
 

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -125,6 +125,15 @@ staticExpectations.forEach(function(expectation) {
   });
 });
 
+test("Escaping works for path length with trailing slashes.", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/foo/:query", handler: handler }]);
+
+  resultsMatch(router.recognize("/foo/%e8%81%8c%e4%bd%8d"), [{ handler: handler, params: { query: '职位' }, isDynamic: true }]);
+  resultsMatch(router.recognize("/foo/%e8%81%8c%e4%bd%8d/"), [{ handler: handler, params: { query: '职位' }, isDynamic: true }]);
+});
+
 test("A simple route with query params recognizes", function() {
   var handler = {};
   var router = new RouteRecognizer();


### PR DESCRIPTION
As identified by Vaanan Vetrivel Kannan, we don't currently handle path length correctly when dealing with encoded characters.

This adds a failing test and a fix.