### PR TITLE
Throws errors when params would result in problems.

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -12,6 +12,19 @@ function isArray(test) {
   return Object.prototype.toString.call(test) === "[object Array]";
 }
 
+function getParam(params, key) {
+  if (typeof params !== "object" || params === null) {
+    throw new Error("You must pass an object as the second argument to `generate`.");
+  }
+  if (!params.hasOwnProperty(key)) {
+    throw new Error("You must provide param `" + key + "` to `generate`.");
+  }
+  if (("" + params[key]).length === 0) {
+    throw new Error("You must provide a param `" + key + "`.");
+  }
+
+  return params[key];
+}
 
 // A Segment represents a segment in the original route description.
 // Each Segment type provides an `eachChar` and `regex` method.
@@ -63,10 +76,12 @@ DynamicSegment.prototype = {
   },
 
   generate: function(params) {
+    var value = getParam(params, this.name);
+
     if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS) {
-      return encodePathSegment(params[this.name]);
+      return encodePathSegment(value);
     } else {
-      return params[this.name];
+      return value;
     }
   }
 };
@@ -82,7 +97,7 @@ StarSegment.prototype = {
   },
 
   generate: function(params) {
-    return params[this.name];
+    return getParam(params, this.name);
   }
 };
 

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -909,6 +909,81 @@ globGenerationValues.forEach(function(value) {
   });
 });
 
+test("Throws when generating dynamic routes with an empty string", function() {
+  var router = new RouteRecognizer();
+  router.add([{ "path": "/posts", "handler": "posts" }, { "path": "/*secret/create", "handler": "create" }], { as: "create" });
+  router.add([{ "path": "/posts", "handler": "posts" }, { "path": "/:secret/edit", "handler": "edit" }], { as: "edit" });
+
+  QUnit.throws(function() {
+    router.generate("create", { secret: "" });
+  }, /You must provide a param `secret`./);
+  QUnit.throws(function() {
+    router.generate("edit", { secret: "" });
+  }, /You must provide a param `secret`./);
+});
+
+test("Fails reasonably when bad params passed to dynamic segment", function() {
+  var router = new RouteRecognizer();
+  router.add([{ "path": "/posts", "handler": "posts" }, { "path": "/*secret/create", "handler": "create" }], { as: "create" });
+  router.add([{ "path": "/posts", "handler": "posts" }, { "path": "/:secret/edit", "handler": "edit" }], { as: "edit" });
+
+  QUnit.throws(function() {
+    router.generate("edit");
+  }, /You must pass an object as the second argument to `generate`./, "No argument passed.");
+
+  QUnit.throws(function() {
+    router.generate("edit", false);
+  }, /You must pass an object as the second argument to `generate`./, "Boolean passed.");
+
+  QUnit.throws(function() {
+    router.generate("edit", null);
+  }, /You must pass an object as the second argument to `generate`./, "`null` passed.");
+
+  QUnit.throws(function() {
+    router.generate("edit", "123");
+  }, /You must pass an object as the second argument to `generate`./, "String passed.");
+
+  QUnit.throws(function() {
+    router.generate("edit", new String("foo"));
+  }, /You must provide param `secret` to `generate`./, "`new String()` passed.");
+
+  QUnit.throws(function() {
+    router.generate("edit", []);
+  }, /You must provide param `secret` to `generate`./, "Array passed.");
+
+  QUnit.throws(function() {
+    router.generate("edit", {});
+  }, /You must provide param `secret` to `generate`./, "Object without own property passed.");
+
+  QUnit.throws(function() {
+    router.generate("create");
+  }, /You must pass an object as the second argument to `generate`./, "No argument passed.");
+
+  QUnit.throws(function() {
+    router.generate("create", false);
+  }, /You must pass an object as the second argument to `generate`./, "Boolean passed.");
+
+  QUnit.throws(function() {
+    router.generate("create", null);
+  }, /You must pass an object as the second argument to `generate`./, "`null` passed.");
+
+  QUnit.throws(function() {
+    router.generate("create", "123");
+  }, /You must pass an object as the second argument to `generate`./, "String passed.");
+
+  QUnit.throws(function() {
+    router.generate("create", new String("foo"));
+  }, /You must provide param `secret` to `generate`./, "`new String()` passed.");
+
+  QUnit.throws(function() {
+    router.generate("create", []);
+  }, /You must provide param `secret` to `generate`./, "Array passed.");
+
+  QUnit.throws(function() {
+    router.generate("create", {});
+  }, /You must provide param `secret` to `generate`./, "Object without own property passed.");
+});
+
 test("Parsing and generation results into the same input string", function() {
   var query = "filter%20data=date";
   equal(router.generateQueryString(router.parseQueryString(query)), '?' + query);


### PR DESCRIPTION
route-recognizer forces both [dynamic segments](https://github.com/tildeio/route-recognizer/blob/master/lib/route-recognizer.js#L62) and [glob segments](https://github.com/tildeio/route-recognizer/blob/master/lib/route-recognizer.js#L81) to always be at least one character long at match time. [This has been the case since the dawn of time. ](https://github.com/tildeio/route-recognizer/blame/4feb8d58e8125725f881185881a4eb56d28ab563/lib/router.js#L54)

Three lines below each of those in the `generate` function we find that there are _no_ checks to prevent generation of a URL which route-recognizer is unable to recognize.

Proposed solution: we should throw an error during dynamic and glob route generation if the parameter is an empty string.

(Issue reported by @meirish.)