### PR TITLE
Fix benchmarks.

### DIFF
--- a/bench/benches/generate.js
+++ b/bench/benches/generate.js
@@ -4,12 +4,12 @@ var router = new RouteRecognizer();
 var i = 1000;
 
 while (i--) {
-  router.add([{ path: "/posts/:id", handler: {} }], { as: "post" });
+  router.add([{ path: "/posts/:id", handler: {} }], { as: "post"+i });
 }
 
 module.exports = {
   name: 'Generate',
   fn: function() {
-    router.generate("post", { id: 1 });
+    router.generate("post1", { id: 1 });
   }
 };

--- a/bench/benches/handlers-for.js
+++ b/bench/benches/handlers-for.js
@@ -4,12 +4,12 @@ var router = new RouteRecognizer();
 var i = 1000;
 
 while (i--) {
-  router.add([{ path: "/foo/" + i, handler: { handler: i } }], { as: 'foo'});
+  router.add([{ path: "/foo/" + i, handler: { handler: i } }], { as: 'foo'+i });
 }
 
 module.exports = {
   name: 'Handlers For',
   fn: function() {
-    router.handlersFor('foo');
+    router.handlersFor('foo1');
   }
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "broccoli-rollup": "^1.0.2",
     "do-you-even-bench": "^1.0.2",
     "ember-cli": "^2.7.0",
+    "glob": "^7.1.1",
     "jshint": "^2.9.3",
     "rollup-plugin-replace": "^1.1.1"
   },


### PR DESCRIPTION
Benchmarks no longer worked as a consequence of not having `glob` as a dependency and changes in allowed invocation patterns. These are also slightly more realistic benchmarks.