### PR TITLE
Bugfix: handle double trailing slashes in paths

### DIFF
--- a/lib/route-recognizer.ts
+++ b/lib/route-recognizer.ts
@@ -636,9 +636,8 @@ class RouteRecognizer {
       originalPath = decodeURI(originalPath);
     }
 
-    let pathLen = path.length;
-    if (pathLen > 1 && path.charAt(pathLen - 1) === "/") {
-      path = path.substr(0, pathLen - 1);
+    while (path.length > 1 && path.charAt(path.length - 1) === "/") {
+      path = path.substr(0, path.length - 1);
       originalPath = originalPath.substr(0, originalPath.length - 1);
       isSlashDropped = true;
     }

--- a/lib/route-recognizer.ts
+++ b/lib/route-recognizer.ts
@@ -636,8 +636,9 @@ class RouteRecognizer {
       originalPath = decodeURI(originalPath);
     }
 
-    while (path.length > 1 && path.charAt(path.length - 1) === "/") {
-      path = path.substr(0, path.length - 1);
+    let pathLen = path.length;
+    if (pathLen > 1 && path.charAt(pathLen - 1) === "/") {
+      path = path.substr(0, pathLen - 1);
       originalPath = originalPath.substr(0, originalPath.length - 1);
       isSlashDropped = true;
     }

--- a/tests/recognizer-tests.ts
+++ b/tests/recognizer-tests.ts
@@ -24,6 +24,14 @@ QUnit.test("A simple route recognizes", (assert: Assert) => {
   assert.equal(router.recognize("/foo/baz"), null);
 });
 
+QUnit.test("A simple route with double trailing slashes recognizes", (assert: Assert) => {
+  let handler = {};
+  let router = new RouteRecognizer();
+  router.add([{ path: "/foo/bar", handler: handler }]);
+  
+  resultsMatch(assert, router.recognize("/foo/bar//"), [{ handler: handler, params: {}, isDynamic: false }]);
+});
+
 const slashStaticExpectations = [{
   // leading only, trailing only, both, neither
   routes: ["/foo/bar", "foo/bar/", "/foo/bar/", "foo/bar"],

--- a/tests/recognizer-tests.ts
+++ b/tests/recognizer-tests.ts
@@ -28,7 +28,7 @@ QUnit.test("A simple route with double trailing slashes recognizes", (assert: As
   let handler = {};
   let router = new RouteRecognizer();
   router.add([{ path: "/foo/bar", handler: handler }]);
-  
+
   resultsMatch(assert, router.recognize("/foo/bar//"), [{ handler: handler, params: {}, isDynamic: false }]);
 });
 


### PR DESCRIPTION
As found by @stefanpenner, double trailing slashes caused hard errors when recognizing paths.

**Changes**:

1. Added failing test
2. Fixed `recognize` to handle trimming double trailing slashes

**How to test drive this PR**:

1. Checkout this branch
2. Run `npm start`
3. Ensure tests pass

Question: Do we need to collapse ε segments throughout the path?