### PR TITLE
Avoid extra allocations

### DIFF
--- a/lib/route-recognizer.ts
+++ b/lib/route-recognizer.ts
@@ -128,15 +128,32 @@ export interface Params {
   queryParams?: QueryParams | null;
 }
 
+interface PopulatedParsedHandlers {
+  names: string[];
+  shouldDecodes: any[];
+}
+
+interface EmptyParsedHandlers {
+  names: ReadonlyArray<any>;
+  shouldDecodes: ReadonlyArray<any>;
+}
+
+type ParsedHandler = PopulatedParsedHandlers | EmptyParsedHandlers;
+
+const EmptyArray = Object.freeze([]) as ReadonlyArray<any>;
+
+
 // The `names` will be populated with the paramter name for each dynamic/star
 // segment. `shouldDecodes` will be populated with a boolean for each dyanamic/star
 // segment, indicating whether it should be decoded during recognition.
-function parse(segments: Segment[], route: string, names: string[], types: [number, number, number], shouldDecodes: boolean[]): void {
+function parse(segments: Segment[], route: string, types: [number, number, number]) {
   // normalize route as not starting with a "/". Recognition will
   // also normalize.
   if (route.length > 0 && route.charCodeAt(0) === CHARS.SLASH) { route = route.substr(1); }
 
   let parts = route.split("/");
+  let names: void | string[] = undefined;
+  let shouldDecodes: void | any[] = undefined;
 
   for (let i = 0; i < parts.length; i++) {
     let part = parts[i];
@@ -157,6 +174,8 @@ function parse(segments: Segment[], route: string, names: string[], types: [numb
 
     if (flags & SegmentFlags.Named) {
       part = part.slice(1);
+      names = names || [];
+      shouldDecodes = shouldDecodes || [];
       names.push(part);
       shouldDecodes.push((flags & SegmentFlags.Decoded) !== 0);
     }
@@ -165,8 +184,16 @@ function parse(segments: Segment[], route: string, names: string[], types: [numb
       types[type]++;
     }
 
-    segments.push({ type, value: normalizeSegment(part) });
+    segments.push({
+      type,
+      value: normalizeSegment(part)
+    });
   }
+
+  return {
+    names: names || EmptyArray,
+    shouldDecodes: names || EmptyArray,
+  } as ParsedHandler;
 }
 
 function isEqualCharSpec(spec: CharSpec, char: number, negate: boolean) {
@@ -175,8 +202,8 @@ function isEqualCharSpec(spec: CharSpec, char: number, negate: boolean) {
 
 interface Handler {
   handler: Opaque;
-  names: string[];
-  shouldDecodes: boolean[];
+  names: ReadonlyArray<any> | string[];
+  shouldDecodes: ReadonlyArray<any> | boolean[];
 }
 
 // A State has a character specification and (`charSpec`) and a list of possible
@@ -387,18 +414,27 @@ function findHandler(state: State, originalPath: string, queryParams: QueryParam
     let shouldDecodes = handler.shouldDecodes;
     let params: Params = {};
 
-    for (let j = 0; j < names.length; j++) {
-      let name = names[j];
-      let capture = captures && captures[currentCapture++];
+    let isDynamic = false;
 
-      if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS && shouldDecodes[j]) {
-        params[name] = capture && decodeURIComponent(capture);
-      } else {
-        params[name] = capture;
+    if (names !== undefined && shouldDecodes !== undefined) {
+      for (let j = 0; j < names.length; j++) {
+        isDynamic = true;
+        let name = names[j];
+        let capture = captures && captures[currentCapture++];
+
+        if (RouteRecognizer.ENCODE_AND_DECODE_PATH_SEGMENTS && shouldDecodes[j]) {
+          params[name] = capture && decodeURIComponent(capture);
+        } else {
+          params[name] = capture;
+        }
       }
     }
 
-    result[i] = { handler: handler.handler, params: params, isDynamic: !!names.length };
+    result[i] = {
+      handler: handler.handler,
+      params,
+      isDynamic
+    };
   }
 
   return result;
@@ -416,7 +452,7 @@ function decodeQueryParamPart(part: string): string {
 
 interface NamedRoute {
   segments: Segment[];
-  handlers: Opaque[];
+  handlers: Handler[];
 }
 
 class RouteRecognizer {
@@ -455,10 +491,7 @@ class RouteRecognizer {
     let j = 0;
     for (let i = 0; i < routes.length; i++) {
       let route = routes[i];
-      let names: string[] = [];
-      let shouldDecodes: boolean[] = [];
-
-      parse(allSegments, route.path, names, types, shouldDecodes);
+      let { names, shouldDecodes } = parse(allSegments, route.path, types);
 
       // preserve j so it points to the start of newly added segments
       for (; j < allSegments.length; j++) {
@@ -476,8 +509,11 @@ class RouteRecognizer {
         currentState = eachChar[segment.type](segment, currentState);
         pattern += regex[segment.type](segment);
       }
-      let handler = { handler: route.handler, names: names, shouldDecodes: shouldDecodes };
-      handlers[i] = handler;
+      handlers[i] = {
+        handler: route.handler,
+        names,
+        shouldDecodes
+      };
     }
 
     if (isEmpty) {
@@ -501,7 +537,7 @@ class RouteRecognizer {
 
       this.names[name] = {
         segments: allSegments,
-        handlers: handlers
+        handlers
       };
     }
   }


### PR DESCRIPTION
handler.{names,shouldDecodes} are often empty, we shouldn’t bother allocating them if they are.

These are very very often empty arrays, we shouldn't alloc/iterate them if we don't need to.

---

Tests are red, I need to actually see yet if this is tannable. 