### PR TITLE
Throw useful error when a named segment has no name.

### DIFF
--- a/lib/route-recognizer.ts
+++ b/lib/route-recognizer.ts
@@ -178,6 +178,10 @@ function parse(segments: Segment[], route: string, types: [number, number, numbe
     if (flags & SegmentFlags.Named) {
       part = part.slice(1);
       names = names || [];
+      if (part === '') {
+        throw new Error(`Missing name for dynamic segment in '/${route}', please provide a name (e.g. \`path: '${type === SegmentType.Star ? '*' : ':'}nameHere'\`)`);
+      }
+
       names.push(part);
 
       shouldDecodes = shouldDecodes || [];

--- a/tests/recognizer-tests.ts
+++ b/tests/recognizer-tests.ts
@@ -896,6 +896,13 @@ QUnit.module("Route Generation", hooks => {
     });
   });
 
+  QUnit.test("Throws when adding dynamic segment without name", (assert: Assert) => {
+    let router = new RouteRecognizer();
+    assert.throws(() => {
+      router.add([{ "path": "/:/create", "handler": "create" }], { as: "create" });
+    }, /Missing name for dynamic segment in '\/\:\/create'/);
+  });
+
   let globGenerationValues = [
     "abc/def",
     "abc%2Fdef",
@@ -914,6 +921,13 @@ QUnit.module("Route Generation", hooks => {
     QUnit.test("Generating a star segment glob route with param '" + value + "' passes value through without modification", (assert: Assert) => {
       assert.equal(router.generate("catchall", { catchall: value }), "/" + value);
     });
+  });
+
+  QUnit.test("Throws when adding glob route without name", (assert: Assert) => {
+    let router = new RouteRecognizer();
+    assert.throws(() => {
+      router.add([{ "path": "/*/create", "handler": "create" }], { as: "create" });
+    }, /Missing name for dynamic segment in '\/\*\/create'/);
   });
 
   QUnit.test("Throws when generating dynamic routes with an empty string", (assert: Assert) => {


### PR DESCRIPTION
Previously, the following would generate a named segment with the name of `""` (empty string). Which amounts to "silent failure" and pretty confusing behavior much later in the application process.

This adds an error that happens quite early (route map generation), that helps steer folks in the right direction.