### PR TITLE
update the library size in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/tildeio/route-recognizer.svg)](https://travis-ci.org/tildeio/route-recognizer)
 
 # About
-`route-recognizer` is a lightweight JavaScript library (under 2k!) that
+`route-recognizer` is a lightweight JavaScript library (under 4kB gzipped!) that
 can be used as the recognizer for a more comprehensive router system
 (such as [`router.js`](https://github.com/tildeio/router.js)).
 


### PR DESCRIPTION
As of 2.2.0 the size of the route-recognizer library is 13.3 kB (minified) and 3.9 kB (minigied gzipped). This PR updates the size information in the README.md file.

Fixes #141