### PR TITLE
Expose Delegate interface

### DIFF
--- a/lib/route-recognizer.ts
+++ b/lib/route-recognizer.ts
@@ -1,6 +1,7 @@
 import { createMap } from "./route-recognizer/util";
 import map, { Delegate, Route, Opaque, MatchDSL } from "./route-recognizer/dsl";
 import { normalizePath, normalizeSegment, encodePathSegment } from "./route-recognizer/normalizer";
+export { Delegate } from './route-recognizer/dsl';
 
 const enum CHARS {
   ANY = -1,


### PR DESCRIPTION
To be able to type router.js we need to expose `Delegate` as `Router` can take a route-recognizer delegate as an option.