### PR TITLE
Route metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ result = router.recognize("/pages/hello/world");
 result === [{ handler: page, params: { path: "hello/world" } }];
 ```
 
+Metadata:
+
+```javascript
+router.add([{ path: "/post/1", handler: page, metadata: { test: 123 } }]);
+
+result = router.recognize("/post/1");
+result === [{ handler: page, params: {}, metadata: { test: 123 } }];
+```
+
+Optionally you can pass in metadata for a given route
+
 # Sorting
 
 If multiple routes all match a path, `route-recognizer`

--- a/lib/route-recognizer.ts
+++ b/lib/route-recognizer.ts
@@ -209,12 +209,14 @@ interface EmptyHandler {
   handler: Opaque;
   names: EmptyArray;
   shouldDecodes: EmptyArray;
+  metadata?: Opaque;
 }
 
 interface PopulatedHandler {
   handler: Opaque;
   names: string [];
   shouldDecodes: boolean[];
+  metadata?: Opaque;
 }
 
 type Handler = EmptyHandler | PopulatedHandler;
@@ -385,6 +387,7 @@ export interface Result {
   handler: Opaque;
   params: Params;
   isDynamic: boolean;
+  metadata?: Opaque;
 }
 
 export interface Results extends ArrayLike<Result | undefined> {
@@ -447,11 +450,17 @@ function findHandler(state: State, originalPath: string, queryParams: QueryParam
       }
     }
 
-    result[i] = {
+    let compiledResult: Result = {
       handler: handler.handler,
       params,
       isDynamic
     };
+
+    if (handler.metadata) {
+      compiledResult.metadata = handler.metadata;
+    }
+
+    result[i] = compiledResult;
   }
 
   return result;
@@ -526,11 +535,17 @@ class RouteRecognizer {
         currentState = eachChar[segment.type](segment, currentState);
         pattern += regex[segment.type](segment);
       }
-      handlers[i] = {
+      let compiledHandler: Handler = {
         handler: route.handler,
         names,
         shouldDecodes
       };
+
+      if (typeof route.metadata === "object") {
+        compiledHandler.metadata = route.metadata;
+      }
+
+      handlers[i] = compiledHandler;
     }
 
     if (isEmpty) {

--- a/lib/route-recognizer/dsl.ts
+++ b/lib/route-recognizer/dsl.ts
@@ -10,6 +10,7 @@ export type Opaque = {} | void | null | undefined;
 export interface Route {
   path: string;
   handler: Opaque;
+  metadata?: Opaque;
   queryParams?: string[];
 }
 
@@ -105,14 +106,14 @@ function generateMatch(startingPath: string, matcher: Matcher, delegate: Delegat
   return match;
 }
 
-function addRoute(routeArray: Route[], path: string, handler: any) {
+function addRoute(routeArray: Route[], path: string, handler: any, metadata: any) {
   let len = 0;
   for (let i = 0; i < routeArray.length; i++) {
     len += routeArray[i].path.length;
   }
 
   path = path.substr(len);
-  let route = { path: path, handler: handler };
+  let route = { path: path, handler: handler, metadata: metadata };
   routeArray.push(route);
 }
 
@@ -122,7 +123,7 @@ function eachRoute<T>(baseRoute: Route[], matcher: Matcher, callback: (this: T, 
   for (let i = 0; i < paths.length; i++) {
     let path = paths[i];
     let routeArray = baseRoute.slice();
-    addRoute(routeArray, path, routes[path]);
+    addRoute(routeArray, path, routes[path], routes.metadata);
     let nested = matcher.children[path];
     if (nested) {
       eachRoute(routeArray, nested, callback, binding);

--- a/tests/recognizer-tests.ts
+++ b/tests/recognizer-tests.ts
@@ -483,6 +483,51 @@ QUnit.test("Multiple routes recognize", (assert: Assert) => {
   resultsMatch(assert, router.recognize("/bar/1"), [{ handler: handler2, params: { baz: "1" }, isDynamic: true }]);
 });
 
+QUnit.test("Object metadata returned in recognize", (assert: Assert) => {
+  let handler = {};
+  let metadata = { test: 1 };
+  let router = new RouteRecognizer();
+  router.add([{ path: "/foo/bar", handler: handler, metadata: metadata }]);
+
+  resultsMatch(assert, router.recognize("/foo/bar"), [{ handler: handler, params: {}, isDynamic: false, metadata: metadata]);
+});
+
+QUnit.test("Undefined metadata not returned in recognize", (assert: Assert) => {
+  let handler = {};
+  let metadata = undefined;
+  let router = new RouteRecognizer();
+  router.add([{ path: "/foo/bar", handler: handler, metadata: metadata }]);
+
+  resultsMatch(assert, router.recognize("/foo/bar"), [{ handler: handler, params: {}, isDynamic: false}]);
+});
+
+QUnit.test("Null metadata not returned in recognize", (assert: Assert) => {
+  let handler = {};
+  let metadata = null;
+  let router = new RouteRecognizer();
+  router.add([{ path: "/foo/bar", handler: handler, metadata: metadata }]);
+
+  resultsMatch(assert, router.recognize("/foo/bar"), [{ handler: handler, params: {}, isDynamic: false}]);
+});
+
+QUnit.test("Boolean true metadata not returned in recognize", (assert: Assert) => {
+  let handler = {};
+  let metadata = true;
+  let router = new RouteRecognizer();
+  router.add([{ path: "/foo/bar", handler: handler, metadata: metadata }]);
+
+  resultsMatch(assert, router.recognize("/foo/bar"), [{ handler: handler, params: {}, isDynamic: false}]);
+});
+
+QUnit.test("Boolean false metadata not returned in recognize", (assert: Assert) => {
+  let handler = {};
+  let metadata = false;
+  let router = new RouteRecognizer();
+  router.add([{ path: "/foo/bar", handler: handler, metadata: metadata }]);
+
+  resultsMatch(assert, router.recognize("/foo/bar"), [{ handler: handler, params: {}, isDynamic: false}]);
+});
+
 QUnit.test("query params ignore the URI malformed error", (assert: Assert) => {
   let handler1 = { handler: 1 };
   let router = new RouteRecognizer();

--- a/tests/router-tests.ts
+++ b/tests/router-tests.ts
@@ -279,9 +279,9 @@ QUnit.module("The match DSL", hooks => {
         });
         match("/").to("index");
       });
-    }, function (router, route) {
-      invocations.push(route.map(e => e.handler).join("."));
-      router.add(route);
+    }, function (recognizer, routes) {
+      invocations.push(routes.map(e => e.handler).join("."));
+      recognizer.add(routes);
     });
 
     const expected = [
@@ -302,6 +302,20 @@ QUnit.module("The match DSL", hooks => {
     ]);
   });
 
+  QUnit.test("supports passing metadata in route", (assert: Assert) => {
+    let metadata = {};
+
+    router.map(function(match) {
+      match("/posts/new").to("newPost");
+    }, function (recognizer, routes) {
+      recognizer.add(routes.map(e => {
+        e.metadata = metadata;
+        return e;
+      }));
+    });
+
+    matchesRoute(assert, "/posts/new", [{ handler: "newPost", params: {}, isDynamic: false, metadata: metadata }]);
+  });
 });
 
 


### PR DESCRIPTION
Adding Route Metadata Option to pass in an object for a given route

 ```javascript
router.add([{ path: "/post/1", handler: page, metadata: { test: 123 } }]);
 result = router.recognize("/post/1");
result === [{ handler: page, params: {}, metadata: { test: 123 } }];
```