### PR TITLE
Don't sort query params

### DIFF
--- a/lib/route-recognizer.ts
+++ b/lib/route-recognizer.ts
@@ -690,7 +690,6 @@ class RouteRecognizer<THandler = string> {
   generateQueryString(params: Params): string {
     const pairs: string[] = [];
     const keys: string[] = Object.keys(params);
-    keys.sort();
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
       const value = params[key];

--- a/tests/recognizer-tests.ts
+++ b/tests/recognizer-tests.ts
@@ -1666,28 +1666,28 @@ QUnit.module("Route Generation", hooks => {
         id: 1,
         queryParams: { format: "markdown", editor: "ace" }
       }),
-      "/posts/1/edit?editor=ace&format=markdown"
+      "/posts/1/edit?format=markdown&editor=ace"
     );
     assert.equal(
       router.generate("edit_post", {
         id: 1,
         queryParams: { format: "markdown", editor: "ace" }
       }),
-      "/posts/1/edit?editor=ace&format=markdown"
+      "/posts/1/edit?format=markdown&editor=ace"
     );
     assert.equal(
       router.generate("edit_post", {
         id: 1,
         queryParams: { format: true, editor: "ace" }
       }),
-      "/posts/1/edit?editor=ace&format=true"
+      "/posts/1/edit?format=true&editor=ace"
     );
     assert.equal(
       router.generate("edit_post", {
         id: 1,
         queryParams: { format: "markdown", editor: true }
       }),
-      "/posts/1/edit?editor=true&format=markdown"
+      "/posts/1/edit?format=markdown&editor=true"
     );
     assert.equal(
       router.generate("foo", { bar: 9, bat: 10, queryParams: { a: 1 } }),


### PR DESCRIPTION
When a query string is generated, the `generateQueryString` function sorts the params alphabetically.

This behavior isn't exactly flawed, but it's unexpected and provides no meaningful benefit.  If a developer always wants their keys to be sorted, it should be done before passing them to the recognizer.  The current implementation makes it impossible to choose how query params are sorted.

I ran into an annoyance with this recently when I changed a route to always be redirected to from an index route at the same level of the hierarchy; this is done by calling `replaceWith` and passing the current queryParams to that function.  The queryParams are passed in the correct order that's already expected, but what happens now that the queryParams get sorted by the recognizer is that my acceptance tests (which assert that the current URL is correct) for the target route have several failures now that the queryParams are sorted differently.  It's not something that can't be easily fixed, but it's extra time the developer needs to spend and is overall unexpected.