### PR TITLE
fix: query param with '=' in value is incorrectly parsed

### DIFF
--- a/lib/route-recognizer.ts
+++ b/lib/route-recognizer.ts
@@ -720,7 +720,7 @@ class RouteRecognizer<THandler = string> {
     const pairs = queryString.split("&");
     const queryParams: QueryParams = {};
     for (let i = 0; i < pairs.length; i++) {
-      const pair = pairs[i].split("=");
+      const pair = pairs[i].split(/=(.*)/, 2);
       let key = decodeQueryParamPart(pair[0]);
       const keyLength = key.length;
       let isArray = false;

--- a/tests/recognizer-tests.ts
+++ b/tests/recognizer-tests.ts
@@ -252,6 +252,24 @@ QUnit.test("Query params without '='", (assert: Assert) => {
   });
 });
 
+QUnit.test("Query params with '=' in value", (assert: Assert) => {
+  const handler = {};
+  const router = new RouteRecognizer<{}>();
+  router.add([{ path: "/foo/bar", handler }]);
+
+  assert.deepEqual(queryParams(router.recognize("/foo/bar?filter=a=b")), {
+    filter: "a=b"
+  });
+  assert.deepEqual(
+    queryParams(
+      router.recognize(
+        `/foo/bar?filter=genres=in=(comedy);actor=="Ryan Reynolds"`
+      )
+    ),
+    { filter: `genres=in=(comedy);actor=="Ryan Reynolds"` }
+  );
+});
+
 QUnit.test(
   "Query params with = and without value are empty string",
   (assert: Assert) => {


### PR DESCRIPTION
Fixes a bug where a query param with `=` in the value, e.g. `?filter=foo=bar` is incorrectly parsed as `filter: 'foo'`. The `=` and anything after it is ignored (`=bar`). However it should be parsed as `filter: 'foo=bar'`.

Related issues:
- https://github.com/tildeio/route-recognizer/issues/167
- https://github.com/pretenderjs/pretender/issues/316